### PR TITLE
Close ParquetFileReader in Parquet.count()

### DIFF
--- a/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/Parquet.kt
+++ b/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/Parquet.kt
@@ -17,8 +17,9 @@ object Parquet {
   fun count(paths: List<Path>, conf: Configuration): Long {
     return paths.sumOf { path ->
       val input = HadoopInputFile.fromPath(path, conf)
-      val reader = ParquetFileReader.open(input)
-      reader.footer.blocks.sumOf { it.rowCount }
+      ParquetFileReader.open(input).use { reader ->
+        reader.footer.blocks.sumOf { it.rowCount }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `Parquet.count()` opened a `ParquetFileReader` per path but never closed it, leaking the underlying file handle every time it was called.
- Wrapping the reader in `.use {}` so it's released after reading the footer.

## Test plan
- [ ] Existing `centurion-parquet` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)