### PR TITLE
Use forEach in ReflectionRecordEncoder.encode

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/ReflectionRecordEncoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/ReflectionRecordEncoder.kt
@@ -62,9 +62,9 @@ class ReflectionRecordEncoder<T : Any>(schema: Schema, kclass: KClass<T>) : Enco
 
    override fun encode(schema: Schema, value: T): GenericRecord {
       val record = GenericData.Record(schema)
-      encoders.map { (encoder, getter, pos, schema) ->
-         val value = getter.apply(value)
-         val encoded = encoder.encode(schema, value)
+      encoders.forEach { (encoder, getter, pos, schema) ->
+         val fieldValue = getter.apply(value)
+         val encoded = encoder.encode(schema, fieldValue)
          record.put(pos, encoded)
       }
       return record


### PR DESCRIPTION
## Summary
- `ReflectionRecordEncoder.encode` used `encoders.map { ... }` only for its side effects (`record.put`), discarding the returned list. On every encode call this allocated a throwaway `ArrayList` sized to the number of fields.
- Switch to `forEach` so the hot path no longer allocates per record.
- Also renamed the inner shadowed `value` to `fieldValue` for clarity (no behaviour change — the inner shadow currently happens to resolve to the outer `T` argument, which was the intent, but it's easy to misread).

## Test plan
- [ ] Existing `centurion-avro` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)