### PR TITLE
Cache per-field writers in StructWriter

### DIFF
--- a/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/writers/StructWriter.kt
+++ b/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/writers/StructWriter.kt
@@ -12,6 +12,8 @@ internal class StructWriter(
   private val root: Boolean
 ) : Writer {
 
+  private val fieldWriters: Array<Writer> = Array(schema.fields.size) { Writer.writerFor(schema.fields[it].schema) }
+
   override fun write(consumer: RecordConsumer, value: Any) {
 
     fun write() {
@@ -26,8 +28,7 @@ internal class StructWriter(
         // null values are handled in parquet by skipping them completely in the file
         if (fieldValue != null) {
           consumer.writeField(field.name, k) {
-            val writer = Writer.writerFor(field.schema)
-            writer.write(consumer, fieldValue)
+            fieldWriters[k].write(consumer, fieldValue)
           }
         }
       }


### PR DESCRIPTION
## Summary
- `StructWriter.write` resolved `Writer.writerFor(field.schema)` on every row for every non-null field, walking the schema-to-writer `when` block each time and re-allocating child `StructWriter` / `ArrayWriter` / `MapWriter` instances for nested types.
- Resolve writers once at construction into a per-field array and reuse on the write path.

## Test plan
- [ ] Existing `centurion-parquet` test suite passes (covers nested structs, arrays, maps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)