### PR TITLE
Add Long/Number fast path to LongWriter

### DIFF
--- a/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/writers/writers.kt
+++ b/centurion-parquet/src/main/kotlin/com/sksamuel/centurion/parquet/writers/writers.kt
@@ -53,7 +53,11 @@ internal object IntegerWriter : Writer {
 }
 
 internal object LongWriter : Writer {
-  override fun write(consumer: RecordConsumer, value: Any) = consumer.addLong(value.toString().toLong())
+  override fun write(consumer: RecordConsumer, value: Any) = when (value) {
+    is Long -> consumer.addLong(value)
+    is Number -> consumer.addLong(value.toLong())
+    else -> consumer.addLong(value.toString().toLong())
+  }
 }
 
 internal object DoubleWriter : Writer {


### PR DESCRIPTION
## Summary
- `LongWriter` always routed values through `value.toString().toLong()`, parsing a fresh `String` on every write even when the value was already a `Long`.
- Add a direct `Long` path and a `Number.toLong()` path (covering `Int`, `Short`, `Byte`, etc.), keeping the `toString().toLong()` route only as the unexpected-type fallback.
- Mirrors the existing structure of `IntegerWriter`.

## Test plan
- [ ] Existing `centurion-parquet` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)