### PR TITLE
Update Gradle wrapper to 9.5.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Bump the wrapper distribution from 8.14.3 to 9.5.0.
- 8.14.3 ships a Kotlin compiler that fails to parse JDK 25's version string (`java.lang.IllegalArgumentException: 25.0.3` from `JavaVersion.parse`), breaking local builds on recent JDKs. 9.x bundles a newer Kotlin that handles it.
- Only `gradle-wrapper.properties` is changed; the wrapper jar/scripts are unchanged and will redownload the new distribution on first run.

## Test plan
- [ ] `./gradlew --version` reports 9.5.0
- [ ] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)