### PR TITLE
Update Kotest to 6.1.11

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 dependencies {
    testImplementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.10")
 
-   val kotestVersion = "6.0.2"
+   val kotestVersion = "6.1.11"
    testImplementation("io.kotest:kotest-framework-engine:$kotestVersion")
    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")


### PR DESCRIPTION
## Summary
- Bump the shared `kotestVersion` in `buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts` from `6.0.2` to `6.1.11` (current latest stable on Maven Central).
- Affects every module via the convention plugin: `kotest-framework-engine`, `kotest-runner-junit5`, `kotest-assertions-core`, `kotest-assertions-json`, `kotest-extensions-testcontainers`, `kotest-property`.

## Test plan
- [ ] `./gradlew test` passes across all modules
- [ ] No kotest 6.0 → 6.1 API regressions surface in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)