### PR TITLE
Add LocalDateTimeDecoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -5,6 +5,7 @@ import org.apache.avro.Schema
 import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.LocalTime
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -64,6 +65,7 @@ fun interface Decoder<T> {
             Set::class -> SetDecoder(decoderFor(type.arguments.first().type!!, nonNullSchema.elementType))
             Map::class -> MapDecoder(decoderFor(type.arguments[1].type!!, nonNullSchema.valueType))
             LocalTime::class -> LocalTimeDecoder
+            LocalDateTime::class -> LocalDateTimeDecoder
             Instant::class -> InstantDecoder
             is KClass<*> if classifier.java.isEnum -> EnumDecoder(classifier as KClass<out Enum<*>>)
             is KClass<*> if classifier.isData -> ReflectionRecordDecoder(schema, classifier)

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
@@ -1,14 +1,19 @@
 package com.sksamuel.centurion.avro.decoders
 
 import org.apache.avro.LogicalTypes
+import org.apache.avro.LogicalTypes.LocalTimestampMicros
+import org.apache.avro.LogicalTypes.LocalTimestampMillis
 import org.apache.avro.LogicalTypes.TimeMicros
 import org.apache.avro.LogicalTypes.TimeMillis
 import org.apache.avro.Schema
+import org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion
+import org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion
 import org.apache.avro.data.TimeConversions.TimeMicrosConversion
 import org.apache.avro.data.TimeConversions.TimeMillisConversion
 import org.apache.avro.data.TimeConversions.TimestampMicrosConversion
 import org.apache.avro.data.TimeConversions.TimestampMillisConversion
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -61,3 +66,23 @@ object LocalTimeDecoder : Decoder<LocalTime> {
 }
 
 val OffsetDateTimeDecoder: Decoder<OffsetDateTime> = InstantDecoder.map { it.atOffset(ZoneOffset.UTC) }
+
+/**
+ * [Decoder] for [LocalDateTime] which supports [LocalTimestampMillis], [LocalTimestampMicros] and Longs.
+ */
+object LocalDateTimeDecoder : Decoder<LocalDateTime> {
+   override fun decode(schema: Schema, value: Any?): LocalDateTime {
+      return when (value) {
+         is Long -> {
+            when (val logicalType = schema.logicalType) {
+               is LocalTimestampMillis -> LocalTimestampMillisConversion().fromLong(value, schema, logicalType)
+               is LocalTimestampMicros -> LocalTimestampMicrosConversion().fromLong(value, schema, logicalType)
+               null -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC)
+               else -> error("Unsupported schema for LocalDateTime: $schema")
+            }
+         }
+
+         else -> error("Unsupported schema and value for LocalDateTime: $schema $value")
+      }
+   }
+}

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/LocalDateTimeDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/LocalDateTimeDecoderTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.centurion.avro.decoders
+
+import com.sksamuel.centurion.avro.encoders.LocalDateTimeEncoder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.LogicalTypes
+import org.apache.avro.Schema
+import java.time.LocalDateTime
+
+class LocalDateTimeDecoderTest : FunSpec({
+
+   test("local timestamp millis") {
+      val schema = Schema.create(Schema.Type.LONG)
+      LogicalTypes.localTimestampMillis().addToSchema(schema)
+      val input = LocalDateTime.of(2026, 5, 12, 10, 20, 30)
+      LocalDateTimeDecoder.decode(schema, LocalDateTimeEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("local timestamp micros") {
+      val schema = Schema.create(Schema.Type.LONG)
+      LogicalTypes.localTimestampMicros().addToSchema(schema)
+      val input = LocalDateTime.of(2026, 5, 12, 10, 20, 30, 123_456_000)
+      LocalDateTimeDecoder.decode(schema, LocalDateTimeEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("long with no logical type is interpreted as epoch millis at UTC") {
+      val schema = Schema.create(Schema.Type.LONG)
+      val input = LocalDateTime.of(2026, 5, 12, 10, 20, 30)
+      LocalDateTimeDecoder.decode(schema, LocalDateTimeEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("unsupported value type fails with a helpful error") {
+      val schema = Schema.create(Schema.Type.LONG)
+      LogicalTypes.localTimestampMillis().addToSchema(schema)
+      shouldThrow<IllegalStateException> {
+         LocalDateTimeDecoder.decode(schema, "not a long")
+      }
+   }
+
+   test("unsupported logical type on a long fails with a helpful error") {
+      val schema = Schema.create(Schema.Type.LONG)
+      LogicalTypes.timeMicros().addToSchema(schema)
+      shouldThrow<IllegalStateException> {
+         LocalDateTimeDecoder.decode(schema, 12345L)
+      }
+   }
+})


### PR DESCRIPTION
## Summary
- `Encoder.encoderFor` mapped `LocalDateTime` to `LocalDateTimeEncoder`, but `Decoder.decoderFor` had no corresponding branch.
- Any data class with a `LocalDateTime` field could be encoded fine but would fail to decode with `error("Unsupported type \$type")`.
- Mirror the encoder by adding `LocalDateTimeDecoder` (handling `LocalTimestampMillis`, `LocalTimestampMicros`, and plain `Long`) and registering it in `Decoder.decoderFor`.

## Test plan
- [ ] Round-trip a data class containing `LocalDateTime` through `ReflectionRecordEncoder` / `ReflectionRecordDecoder`
- [ ] Existing `centurion-avro` test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)