### PR TITLE
Add BigDecimal decoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -2,6 +2,7 @@ package com.sksamuel.centurion.avro.decoders
 
 import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
+import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.LocalTime
@@ -38,6 +39,7 @@ fun interface Decoder<T> {
             Long::class -> LongDecoder
             Byte::class -> ByteDecoder
             Short::class -> ShortDecoder
+            BigDecimal::class -> BigDecimalStringDecoder
             ByteArray::class -> ByteArrayDecoder
             ByteBuffer::class -> ByteBufferDecoder
             List::class if type.arguments.first().type == typeOf<Long>() -> PassthroughListDecoder

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
@@ -1,0 +1,58 @@
+package com.sksamuel.centurion.avro.decoders
+
+import org.apache.avro.Conversions
+import org.apache.avro.LogicalTypes
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericFixed
+import org.apache.avro.util.Utf8
+import java.math.BigDecimal
+import java.nio.ByteBuffer
+
+/**
+ * A [Decoder] for [BigDecimal] that decodes from byte arrays.
+ */
+object BigDecimalBytesDecoder : Decoder<BigDecimal> {
+
+   private val converter = Conversions.DecimalConversion()
+
+   override fun decode(schema: Schema, value: Any?): BigDecimal {
+      require(schema.type == Schema.Type.BYTES)
+      val logical = schema.logicalType as LogicalTypes.Decimal
+      return when (value) {
+         is ByteBuffer -> converter.fromBytes(value, schema, logical)
+         is ByteArray -> converter.fromBytes(ByteBuffer.wrap(value), schema, logical)
+         else -> error("Unsupported value for BigDecimal bytes decoder: $value")
+      }
+   }
+}
+
+/**
+ * A [Decoder] for [BigDecimal] that decodes from Strings.
+ */
+object BigDecimalStringDecoder : Decoder<BigDecimal> {
+   override fun decode(schema: Schema, value: Any?): BigDecimal {
+      require(schema.type == Schema.Type.STRING)
+      return when (value) {
+         is CharSequence -> BigDecimal(value.toString())
+         is Utf8 -> BigDecimal(value.toString())
+         else -> error("Unsupported value for BigDecimal string decoder: $value")
+      }
+   }
+}
+
+/**
+ * A [Decoder] for [BigDecimal] that decodes from fixed size byte arrays.
+ */
+object BigDecimalFixedDecoder : Decoder<BigDecimal> {
+
+   private val converter = Conversions.DecimalConversion()
+
+   override fun decode(schema: Schema, value: Any?): BigDecimal {
+      require(schema.type == Schema.Type.FIXED)
+      val logical = schema.logicalType as LogicalTypes.Decimal
+      return when (value) {
+         is GenericFixed -> converter.fromFixed(value, schema, logical)
+         else -> error("Unsupported value for BigDecimal fixed decoder: $value")
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- `Encoder.encoderFor` mapped `BigDecimal` to `BigDecimalStringEncoder` (with `BigDecimalBytesEncoder` / `BigDecimalFixedEncoder` also available for explicit use), but there were no corresponding decoders.
- Any data class with a `BigDecimal` field could be encoded but not decoded — `decoderFor` fell through to `error("Unsupported type \$type")`.
- Adds the three mirror decoders (`BigDecimalBytesDecoder`, `BigDecimalStringDecoder`, `BigDecimalFixedDecoder`) and registers the String variant in `Decoder.decoderFor` to match the default encoder.

## Test plan
- [ ] Round-trip a data class containing `BigDecimal` through `ReflectionRecordEncoder` / `ReflectionRecordDecoder`
- [ ] Existing `centurion-avro` test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)