### PR TITLE
Read only the remaining bytes from the ByteBuffer in GenericRecordCodec.decode

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
@@ -38,14 +38,8 @@ class GenericRecordCodec(
 
    private fun decode(buffer: ByteBuffer): GenericRecord {
       val datum = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
-      val bytes: ByteArray = when (buffer.hasArray()) {
-         true -> buffer.array()
-         else -> {
-            val bytesArray = ByteArray(buffer.remaining())
-            buffer.get(bytesArray, 0, bytesArray.size)
-            bytesArray
-         }
-      }
+      val bytes = ByteArray(buffer.remaining())
+      buffer.get(bytes)
       val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
       return datum.read(null, decoder)
    }

--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
@@ -45,14 +45,8 @@ class ReflectionDataClassCodec<T : Any>(
 
    private fun read(buffer: ByteBuffer): GenericRecord {
       val datum = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
-      val bytes: ByteArray = when (buffer.hasArray()) {
-         true -> buffer.array()
-         else -> {
-            val bytesArray = ByteArray(buffer.remaining())
-            buffer.get(bytesArray, 0, bytesArray.size)
-            bytesArray
-         }
-      }
+      val bytes = ByteArray(buffer.remaining())
+      buffer.get(bytes)
       val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
       return datum.read(null, decoder)
    }


### PR DESCRIPTION
## Summary
- `GenericRecordCodec.decode` had a `hasArray()` fast-path that returned `buffer.array()` — the entire backing array — ignoring `position`, `limit`, and `arrayOffset`.
- Lettuce / Netty buffers routinely share a single backing array between many logical buffers, so this fed the Avro decoder bytes from outside the current buffer's window (and often skipped its real contents entirely), producing either decode failures or wrong records.
- Replace with the always-correct path: allocate `ByteArray(buffer.remaining())` and bulk-get into it.

## Test plan
- [ ] Round-trip a `GenericRecord` through `GenericRecordCodec.encodeValue` / `decodeValue` and assert equality
- [ ] Run against a live Lettuce + Redis testcontainer if there's existing harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)