### PR TITLE
Error explicitly when a constructor parameter is missing from the Avro schema

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
@@ -67,6 +67,7 @@ class ReflectionRecordDecoder<T : Any>(
 
       val decoders = constructor.parameters.map { param ->
          val avroField = schema.getField(param.name)
+            ?: error("Could not find field ${param.name} in Avro schema")
          val decoder = Decoder.decoderFor(param.type, avroField.schema())
          Decoding(avroField.pos(), decoder, avroField.schema())
       }


### PR DESCRIPTION
## Summary
- `ReflectionRecordDecoder.buildDecodeFn` called `schema.getField(param.name)` and immediately dereferenced `.schema()` on the result.
- If a constructor parameter didn't appear in the Avro schema, that produced a bare `NullPointerException` pointing at the next line — no indication of which field was missing.
- Mirror the encoder side, which already does `?: error("Could not find field …")`.

## Test plan
- [ ] Build a decoder for a data class whose constructor names a field not in the schema; expect a clear `IllegalStateException` instead of an NPE.
- [ ] Existing test suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)