### PR TITLE
Avoid per-decode List allocation in ReflectionRecordDecoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
@@ -72,11 +72,11 @@ class ReflectionRecordDecoder<T : Any>(
       }
 
       return { record ->
-         val args = decoders.map { (pos, decoder, schema) ->
-            val value = record.get(pos)
-            decoder.decode(schema, value)
+         val args = Array(decoders.size) { i ->
+            val (pos, decoder, fieldSchema) = decoders[i]
+            decoder.decode(fieldSchema, record.get(pos))
          }
-         constructor.call(*args.toTypedArray())
+         constructor.call(*args)
       }
    }
 


### PR DESCRIPTION
## Summary
- `ReflectionRecordDecoder.buildDecodeFn` built `args` via `decoders.map { ... }.toTypedArray()` — allocating an `ArrayList` sized to the constructor's parameter count and then copying it into an `Array` on every decode.
- Switch to `Array(decoders.size) { i -> ... }` so the spread argument lands directly in the `Array<Any?>` we need for `constructor.call(*args)`, eliminating the intermediate list per record.

## Test plan
- [ ] Existing `centurion-avro` test suite passes
- [ ] DeserializeBenchmark in `centurion-benchmarks` shows no regression (ideally a modest improvement on records with many fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)