### PR TITLE
Honour ByteBuffer position/limit in string decoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
@@ -17,7 +17,7 @@ object StringDecoder : Decoder<String> {
       return when (value) {
          is CharSequence -> value.toString() // covers String and Utf8 as well
          is ByteArray -> Utf8(value).toString()
-         is ByteBuffer -> Utf8(value.array()).toString()
+         is ByteBuffer -> Utf8(value.readRemainingBytes()).toString()
          is GenericFixed -> Utf8(value.bytes()).toString()
          else -> error("Unsupported type $value")
       }
@@ -53,7 +53,7 @@ object UTF8Decoder : Decoder<Utf8> {
       return when (value) {
          is CharSequence -> Utf8(value.toString())
          is ByteArray -> Utf8(value)
-         is ByteBuffer -> Utf8(value.array())
+         is ByteBuffer -> Utf8(value.readRemainingBytes())
          is GenericFixed -> Utf8(value.bytes())
          else -> error("Unsupported type $value")
       }
@@ -91,10 +91,16 @@ object ByteStringDecoder : Decoder<String> {
       require(schema.type == Schema.Type.BYTES)
       return when (value) {
          is ByteArray -> Utf8(value).toString()
-         is ByteBuffer -> Utf8(value.array()).toString()
+         is ByteBuffer -> Utf8(value.readRemainingBytes()).toString()
          else -> error("This decoder expects bytes but was $value")
       }
    }
+}
+
+private fun ByteBuffer.readRemainingBytes(): ByteArray {
+   val bytes = ByteArray(remaining())
+   get(bytes)
+   return bytes
 }
 
 /**

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringDecoderTest.kt
@@ -37,4 +37,92 @@ class StringDecoderTest : FunSpec({
       ) shouldBe "foo"
    }
 
+   test("decode byte buffer that has been advanced past leading bytes") {
+      val schema = SchemaBuilder.builder().stringType()
+      val buffer = ByteBuffer.wrap("xxxfoo".encodeToByteArray())
+      buffer.position(3)
+      StringDecoder.decode(schema, buffer) shouldBe "foo"
+   }
+
+   test("decode byte buffer with limit set before the end of the backing array") {
+      val schema = SchemaBuilder.builder().stringType()
+      val buffer = ByteBuffer.wrap("fooyyy".encodeToByteArray())
+      buffer.limit(3)
+      StringDecoder.decode(schema, buffer) shouldBe "foo"
+   }
+
+   test("decode a sliced byte buffer that shares its backing array") {
+      val schema = SchemaBuilder.builder().stringType()
+      val backing = ByteBuffer.wrap("xxxfooyyy".encodeToByteArray())
+      backing.position(3)
+      backing.limit(6)
+      val slice = backing.slice()
+      StringDecoder.decode(schema, slice) shouldBe "foo"
+   }
+
+})
+
+class UTF8DecoderTest : FunSpec({
+
+   test("decode java strings") {
+      val schema = SchemaBuilder.builder().stringType()
+      UTF8Decoder.decode(schema, "foo") shouldBe Utf8("foo")
+   }
+
+   test("decode byte array") {
+      val schema = SchemaBuilder.builder().bytesType()
+      UTF8Decoder.decode(schema, "foo".encodeToByteArray()) shouldBe Utf8("foo")
+   }
+
+   test("decode byte buffer") {
+      val schema = SchemaBuilder.builder().bytesType()
+      UTF8Decoder.decode(schema, ByteBuffer.wrap("foo".encodeToByteArray())) shouldBe Utf8("foo")
+   }
+
+   test("decode byte buffer that has been advanced past leading bytes") {
+      val schema = SchemaBuilder.builder().bytesType()
+      val buffer = ByteBuffer.wrap("xxxfoo".encodeToByteArray())
+      buffer.position(3)
+      UTF8Decoder.decode(schema, buffer) shouldBe Utf8("foo")
+   }
+
+   test("decode a sliced byte buffer that shares its backing array") {
+      val schema = SchemaBuilder.builder().bytesType()
+      val backing = ByteBuffer.wrap("xxxfooyyy".encodeToByteArray())
+      backing.position(3)
+      backing.limit(6)
+      val slice = backing.slice()
+      UTF8Decoder.decode(schema, slice) shouldBe Utf8("foo")
+   }
+
+})
+
+class ByteStringDecoderTest : FunSpec({
+
+   test("decode byte array") {
+      val schema = SchemaBuilder.builder().bytesType()
+      ByteStringDecoder.decode(schema, "foo".encodeToByteArray()) shouldBe "foo"
+   }
+
+   test("decode byte buffer") {
+      val schema = SchemaBuilder.builder().bytesType()
+      ByteStringDecoder.decode(schema, ByteBuffer.wrap("foo".encodeToByteArray())) shouldBe "foo"
+   }
+
+   test("decode byte buffer that has been advanced past leading bytes") {
+      val schema = SchemaBuilder.builder().bytesType()
+      val buffer = ByteBuffer.wrap("xxxfoo".encodeToByteArray())
+      buffer.position(3)
+      ByteStringDecoder.decode(schema, buffer) shouldBe "foo"
+   }
+
+   test("decode a sliced byte buffer that shares its backing array") {
+      val schema = SchemaBuilder.builder().bytesType()
+      val backing = ByteBuffer.wrap("xxxfooyyy".encodeToByteArray())
+      backing.position(3)
+      backing.limit(6)
+      val slice = backing.slice()
+      ByteStringDecoder.decode(schema, slice) shouldBe "foo"
+   }
+
 })


### PR DESCRIPTION
## Summary
- `StringDecoder`, `UTF8Decoder`, and `ByteStringDecoder` each handled a `ByteBuffer` input by calling `value.array()` and wrapping the entire backing array in a `Utf8` — ignoring `position`, `limit`, and `arrayOffset`.
- For any sliced or positioned `ByteBuffer` (which is common — Avro hands the same backing array to many logical buffers), the resulting `String` contained bytes outside the buffer's window and often missed its real contents.
- Same defect as the one just fixed in the Lettuce `GenericRecordCodec`.
- Fix: read only the remaining bytes via a small helper, mirroring how `ByteArrayDecoder` / `ByteBufferDecoder` already do it.

## Test plan
- [ ] Decode a positioned/sliced `ByteBuffer` and assert the resulting `String` matches the buffer's window, not the whole backing array
- [ ] Existing `centurion-avro` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)