### PR TITLE
Honour ByteBuffer position/limit in CompressingSerde.deserialize

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/CompressingSerde.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/CompressingSerde.kt
@@ -26,6 +26,9 @@ class CompressingSerde<T : Any>(
    }
 
    override fun deserialize(bytes: ByteArray): T {
-      return serde.deserialize(codec.decompress(ByteBuffer.wrap(bytes)).array())
+      val decompressed = codec.decompress(ByteBuffer.wrap(bytes))
+      val b = ByteArray(decompressed.remaining())
+      decompressed.get(b)
+      return serde.deserialize(b)
    }
 }


### PR DESCRIPTION
## Summary
- `CompressingSerde.deserialize` fed the delegate serde via `codec.decompress(...).array()`, returning the entire backing array regardless of the buffer's position and limit.
- Avro `Codec` implementations are free to return a buffer with arbitrary `position` / `arrayOffset` (e.g. a slice into a larger pooled array), so this could pass extra bytes — or completely wrong bytes — to the inner serde.
- The serialize path already does the right thing (`ByteArray(remaining())` + `get`); apply the same pattern on deserialize.

## Test plan
- [ ] Round-trip a record through `CompressingSerde` with a codec whose `decompress` returns a positioned buffer (e.g. snappy) and assert equality.
- [ ] Existing `centurion-avro` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)