### PR TITLE
Decode primitive arrays directly without boxed intermediates

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -4,10 +4,11 @@ import org.apache.avro.Schema
 
 class IntArrayDecoder(private val decoder: Decoder<Int>) : Decoder<IntArray> {
    override fun decode(schema: Schema, value: Any?): IntArray {
+      val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is List<*> -> value.map { decoder.decode(schema.elementType, it) }.toTypedArray().toIntArray()
-         is Array<*> -> value.map { decoder.decode(schema.elementType, it) }.toTypedArray().toIntArray()
+         is List<*> -> IntArray(value.size) { i -> decoder.decode(elementType, value[i]) }
+         is Array<*> -> IntArray(value.size) { i -> decoder.decode(elementType, value[i]) }
          else -> error("Unsupported list type $value")
       }
    }
@@ -15,10 +16,11 @@ class IntArrayDecoder(private val decoder: Decoder<Int>) : Decoder<IntArray> {
 
 class LongArrayDecoder(private val decoder: Decoder<Long>) : Decoder<LongArray> {
    override fun decode(schema: Schema, value: Any?): LongArray {
+      val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is List<*> -> value.map { decoder.decode(schema.elementType, it) }.toTypedArray().toLongArray()
-         is Array<*> -> value.map { decoder.decode(schema.elementType, it) }.toTypedArray().toLongArray()
+         is List<*> -> LongArray(value.size) { i -> decoder.decode(elementType, value[i]) }
+         is Array<*> -> LongArray(value.size) { i -> decoder.decode(elementType, value[i]) }
          else -> error("Unsupported list type $value")
       }
    }


### PR DESCRIPTION
## Summary
- `IntArrayDecoder` and `LongArrayDecoder` built each result via `value.map { ... }.toTypedArray().toIntArray()` — which allocates an `ArrayList<Int>`, then a boxed `Array<Int>`, and only then unboxes into the `IntArray` we wanted in the first place. Same for `Long`.
- Decode straight into the `IntArray` / `LongArray` via the `(size, init)` constructor. Avro's array values support indexed access (`GenericArray` and `Array<*>`), so this is one allocation per decode instead of three, with no per-element boxing.

## Test plan
- [ ] Existing `centurion-avro` test suite passes
- [ ] DeserializeBenchmark with primitive-array fields shows reduced allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)