### PR TITLE
Fix broken field names in deserializeProgramatically benchmark helper

### DIFF
--- a/centurion-benchmarks/src/jmh/kotlin/com/sksamuel/centurion/avro/benchmarks/testdata.kt
+++ b/centurion-benchmarks/src/jmh/kotlin/com/sksamuel/centurion/avro/benchmarks/testdata.kt
@@ -155,6 +155,7 @@ fun createRecordProgramatically(foo: Foo): GenericData.Record {
 }
 
 fun deserializeProgramatically(record: GenericRecord): Foo {
+   @Suppress("UNCHECKED_CAST")
    return Foo(
       field_a = record.get("field_a").toString(),
       field_b = record.get("field_b") as Boolean,
@@ -164,14 +165,21 @@ fun deserializeProgramatically(record: GenericRecord): Foo {
       field_f = record.get("field_f").toString(),
       field_g = record.get("field_g").toString(),
       field_h = record.get("field_h") as Int,
-      enum = Enum.valueOf((record.get("listOfEnums") as GenericData.EnumSymbol).toString()),
+      enum = Enum.valueOf((record.get("enum") as GenericData.EnumSymbol).toString()),
       listOfEnums = (record.get("listOfEnums") as List<GenericData.EnumSymbol>)
          .map { Enum.valueOf(it.toString()) },
       setOfEnums = (record.get("setOfEnums") as List<GenericData.EnumSymbol>)
          .map { Enum.valueOf(it.toString()) }
          .toSet(),
-      listOfLongs = record.get("field_i") as List<Long>,
-      setOfStrings = (record.get("field_j") as List<String>).toSet(),
-      complexList = record.get("field_k") as List<Bar>,
+      listOfLongs = record.get("listOfLongs") as List<Long>,
+      setOfStrings = (record.get("setOfStrings") as List<CharSequence>).map { it.toString() }.toSet(),
+      complexList = (record.get("complexList") as List<GenericRecord>).map { barRecord ->
+         Bar(
+            field_a = barRecord.get("field_a").toString(),
+            field_b = barRecord.get("field_b") as Boolean,
+            field_c = barRecord.get("field_c") as Int,
+            field_d = barRecord.get("field_d") as Double,
+         )
+      },
    )
 }


### PR DESCRIPTION
## Summary
The "programmatic deserialization" baseline used by `DeserializeBenchmark.deserializeAvroProgramatically{NoReuse,WithReuse}` was reading the wrong fields and casting the wrong types:
- `enum` was read from `"listOfEnums"` and then cast to a single `EnumSymbol` (the value is a `List`).
- `listOfLongs`, `setOfStrings`, and `complexList` were read from non-existent record keys `"field_i"`, `"field_j"`, `"field_k"` — `record.get` returned null and the as-casts threw `NullPointerException`.
- `complexList` was cast to `List<Bar>` but the record holds `List<GenericRecord>`; even if the field name had been right, the cast would have failed.

Fix all three: read the actual schema field names, and decode each `Bar` element from its `GenericRecord`. `setOfStrings` is read as `List<CharSequence>` (Avro returns `Utf8`) and `toString()`'d.

Without this fix the programmatic-baseline benchmarks always threw before producing a number, so any comparison against them was invalid.

## Test plan
- [ ] `./gradlew :centurion-benchmarks:jmh -Pjmh.args="DeserializeBenchmark.deserializeAvroProgramatically*"` produces numbers instead of errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)