### PR TITLE
Reject oversized inputs in FixedByteArrayEncoder explicitly

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bytes.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bytes.kt
@@ -38,6 +38,8 @@ object FixedByteArrayEncoder : Encoder<ByteArray> {
    private val instance = GenericData.get()
    override fun encode(schema: Schema, value: ByteArray): Any? {
       require(schema.type == Schema.Type.FIXED)
+      if (value.size > schema.fixedSize)
+         error("Cannot write ByteArray with ${value.size} bytes to fixed type of size ${schema.fixedSize}")
       val array = ByteArray(schema.fixedSize)
       System.arraycopy(value, 0, array, 0, value.size)
       return instance.createFixed(null, array, schema)


### PR DESCRIPTION
## Summary
- When the caller passed a `ByteArray` larger than `schema.fixedSize`, `System.arraycopy(value, 0, array, 0, value.size)` threw an obscure `ArrayIndexOutOfBoundsException` from inside the standard library.
- Mirror `FixedStringEncoder`'s existing pattern and emit a meaningful error up front instead.

## Test plan
- [ ] Encoding a `ByteArray` longer than the fixed schema size raises the new explicit error rather than an AIOOBE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)