### PR TITLE
Use mapValues in MapEncoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
@@ -82,9 +82,7 @@ class MapEncoder<T>(
 ) : Encoder<Map<String, T>> {
    override fun encode(schema: Schema, value: Map<String, T>): Map<String, Any?> {
       require(schema.type == Schema.Type.MAP)
-      return if (value.isEmpty()) emptyMap()
-      else value.map { (key, value) ->
-         key.toString() to valueEncoder.encode(schema.valueType, value)
-      }.toMap()
+      if (value.isEmpty()) return emptyMap()
+      return value.mapValues { (_, v) -> valueEncoder.encode(schema.valueType, v) }
    }
 }


### PR DESCRIPTION
## Summary
- `MapEncoder.encode` built the result via `.map { (k, v) -> k.toString() to encode(v) }.toMap()` — allocating a `Pair` per entry, a `List<Pair>` for the whole map, and then a fresh `LinkedHashMap` that copied the pairs back in.
- `key.toString()` was also redundant: the key type is already `String`.
- `mapValues` walks the entries once, applies the transform to each value, and returns a `Map` of the same size and key set without any of the intermediate Pair / List allocations.

## Test plan
- [ ] Existing `centurion-avro` test suite passes (`MapEncoderTest` covers round-trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)