### PR TITLE
Fill the result LinkedHashMap directly in MapDecoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -78,9 +78,12 @@ class MapDecoder<T>(private val decoder: Decoder<T>) : Decoder<Map<String, T>> {
    override fun decode(schema: Schema, value: Any?): Map<String, T> {
       return when (value) {
          is Map<*, *> -> {
-            value.map { (k, v) ->
-               StringDecoder.decode(STRING_SCHEMA, k) to decoder.decode(schema.valueType, v)
-            }.toMap()
+            val valueType = schema.valueType
+            val result = LinkedHashMap<String, T>(value.size)
+            value.forEach { (k, v) ->
+               result[StringDecoder.decode(STRING_SCHEMA, k)] = decoder.decode(valueType, v)
+            }
+            result
          }
          else -> error("Unsupported map type $value")
       }


### PR DESCRIPTION
## Summary
- `MapDecoder.decode` built its result via `.map { (k, v) -> ... }.toMap()` — one `Pair` per entry, a `List<Pair>` for the whole map, and a `LinkedHashMap` that re-imported each pair.
- Allocate a pre-sized `LinkedHashMap<String, T>(value.size)` once and fill it via `forEach`, skipping the `Pair` and `List` allocations entirely.
- Also hoists `schema.valueType` out of the per-entry loop (the call itself is cheap, but no reason to repeat it).

## Test plan
- [ ] Existing `centurion-avro` test suite passes (`MapDecoderTest` covers round-trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)