### PR TITLE
Cache atomically in CachingSerdeFactory

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/SerdeFactory.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/SerdeFactory.kt
@@ -37,6 +37,6 @@ class DataSerdeFactory(
 class CachingSerdeFactory(private val underlying: SerdeFactory) : SerdeFactory {
    private val cache = ConcurrentHashMap<KClass<*>, Serde<*>>()
    override fun <T : Any> serdeFor(kclass: KClass<T>): Serde<T> {
-      return cache.getOrPut(kclass) { underlying.serdeFor(kclass) } as Serde<T>
+      return cache.computeIfAbsent(kclass) { underlying.serdeFor(it as KClass<Any>) } as Serde<T>
    }
 }


### PR DESCRIPTION
## Summary
- `cache.getOrPut { ... }` is the standard library's get-then-put extension, **not** `ConcurrentHashMap`'s atomic compute. Under contention, several threads each see the miss, each call `underlying.serdeFor(kclass)` — building a fresh `ReflectionRecordEncoder`/`ReflectionRecordDecoder` per call — and race to `put`. The last write wins, but the threads that received the losers still hold separate `Serde` instances.
- Use `ConcurrentHashMap.computeIfAbsent` so the build lambda runs at most once per key.

## Test plan
- [ ] Existing `centurion-avro` test suite passes
- [ ] Concurrently call `serdeFor` for the same class from N threads and assert `underlying.serdeFor` was invoked once (if there's a fixture harness for it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)