### PR TITLE
Honour ByteBuffer position in byte decoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bytes.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bytes.kt
@@ -11,7 +11,7 @@ object ByteArrayDecoder : Decoder<ByteArray> {
          is GenericData.Fixed -> value.bytes()
          is ByteBuffer -> {
             val array = ByteArray(value.remaining())
-            value.get(array)
+            value.duplicate().get(array)
             array
          }
          else -> error("Cannot decode ${value?.javaClass} as ByteArray")
@@ -26,7 +26,7 @@ object ByteBufferDecoder : Decoder<ByteBuffer> {
          is GenericData.Fixed -> ByteBuffer.wrap(value.bytes())
          is ByteBuffer -> {
             val array = ByteArray(value.remaining())
-            value.get(array)
+            value.duplicate().get(array)
             ByteBuffer.wrap(array)
          }
          else -> error("Cannot decode ${value?.javaClass} as ByteBuffer")

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/ByteArrayDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/ByteArrayDecoderTest.kt
@@ -1,0 +1,47 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import java.nio.ByteBuffer
+
+class ByteArrayDecoderTest : FunSpec({
+
+   test("decode from ByteArray returns the input as-is") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val bytes = byteArrayOf(1, 2, 3)
+      ByteArrayDecoder.decode(schema, bytes) shouldBe bytes
+   }
+
+   test("decode from GenericFixed returns its bytes") {
+      val schema = SchemaBuilder.builder().fixed("f").size(3)
+      val fixed = GenericData.get().createFixed(null, byteArrayOf(7, 8, 9), schema) as GenericData.Fixed
+      ByteArrayDecoder.decode(schema, fixed) shouldBe byteArrayOf(7, 8, 9)
+   }
+
+   test("decode from ByteBuffer reads only the remaining bytes") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4, 5))
+      buffer.position(2)
+      ByteArrayDecoder.decode(schema, buffer) shouldBe byteArrayOf(3, 4, 5)
+   }
+
+   test("decode does not mutate the source ByteBuffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4))
+      buffer.position(1)
+      ByteArrayDecoder.decode(schema, buffer)
+      buffer.position() shouldBe 1
+      buffer.remaining() shouldBe 3
+   }
+
+   test("decoding the same ByteBuffer twice yields the same bytes") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4))
+      buffer.position(1)
+      ByteArrayDecoder.decode(schema, buffer) shouldBe byteArrayOf(2, 3, 4)
+      ByteArrayDecoder.decode(schema, buffer) shouldBe byteArrayOf(2, 3, 4)
+   }
+})

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/ByteBufferDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/ByteBufferDecoderTest.kt
@@ -1,0 +1,58 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import java.nio.ByteBuffer
+
+class ByteBufferDecoderTest : FunSpec({
+
+   test("decode from ByteArray wraps it without copy") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val bytes = byteArrayOf(1, 2, 3)
+      val decoded = ByteBufferDecoder.decode(schema, bytes)
+      val out = ByteArray(decoded.remaining())
+      decoded.get(out)
+      out shouldBe bytes
+   }
+
+   test("decode from GenericFixed wraps its bytes") {
+      val schema = SchemaBuilder.builder().fixed("f").size(3)
+      val fixed = GenericData.get().createFixed(null, byteArrayOf(7, 8, 9), schema) as GenericData.Fixed
+      val decoded = ByteBufferDecoder.decode(schema, fixed)
+      val out = ByteArray(decoded.remaining())
+      decoded.get(out)
+      out shouldBe byteArrayOf(7, 8, 9)
+   }
+
+   test("decode from ByteBuffer reads only the remaining bytes") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4, 5))
+      buffer.position(2)
+      val decoded = ByteBufferDecoder.decode(schema, buffer)
+      val out = ByteArray(decoded.remaining())
+      decoded.get(out)
+      out shouldBe byteArrayOf(3, 4, 5)
+   }
+
+   test("decode does not mutate the source ByteBuffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4))
+      buffer.position(1)
+      ByteBufferDecoder.decode(schema, buffer)
+      buffer.position() shouldBe 1
+      buffer.remaining() shouldBe 3
+   }
+
+   test("decoding the same ByteBuffer twice yields the same bytes") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap(byteArrayOf(1, 2, 3, 4))
+      buffer.position(1)
+      val out1 = ByteArray(3).also { ByteBufferDecoder.decode(schema, buffer).get(it) }
+      val out2 = ByteArray(3).also { ByteBufferDecoder.decode(schema, buffer).get(it) }
+      out1 shouldBe byteArrayOf(2, 3, 4)
+      out2 shouldBe byteArrayOf(2, 3, 4)
+   }
+})


### PR DESCRIPTION
## Summary
Decoder-side mirror of #31. `ByteArrayDecoder` and `ByteBufferDecoder` both called `value.get(array)` directly on the input `ByteBuffer`, which advances its position by `remaining()`. Any caller that decodes the same buffer twice — or that still cares about the buffer's position after decoding — would see corrupted or empty reads.

Use `value.duplicate().get(...)` so the source buffer is left untouched, matching the fix already applied across the string decoders, \`CompressingSerde\`, the Lettuce codecs, and the byte encoders.

## Test plan
- [x] New ByteArrayDecoderTest covering as-is, GenericFixed, positioned ByteBuffer, position-not-mutated, and decode-twice cases.
- [x] New ByteBufferDecoderTest covering the same surface.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)