### PR TITLE
Fill the result LinkedHashSet directly in SetDecoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -62,10 +62,19 @@ object PassthroughSetDecoder : Decoder<Set<Any?>> {
 
 class SetDecoder<T>(private val decoder: Decoder<T>) : Decoder<Set<T>> {
    override fun decode(schema: Schema, value: Any?): Set<T> {
+      val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is Collection<*> -> value.map { decoder.decode(schema.elementType, it) }.toSet()
-         is Array<*> -> value.map { decoder.decode(schema.elementType, it) }.toSet()
+         is Collection<*> -> {
+            val result = LinkedHashSet<T>(value.size)
+            value.forEach { result.add(decoder.decode(elementType, it)) }
+            result
+         }
+         is Array<*> -> {
+            val result = LinkedHashSet<T>(value.size)
+            value.forEach { result.add(decoder.decode(elementType, it)) }
+            result
+         }
          else -> error("Unsupported set type $value")
       }
    }

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/SetDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/SetDecoderTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
+
+class SetDecoderTest : FunSpec({
+
+   test("decoding a List of strings") {
+      val schema = Schema.createArray(Schema.create(Schema.Type.STRING))
+      SetDecoder(StringDecoder).decode(schema, listOf(Utf8("foo"), Utf8("bar"))) shouldBe setOf("foo", "bar")
+   }
+
+   test("decoding an Array of strings") {
+      val schema = Schema.createArray(Schema.create(Schema.Type.STRING))
+      SetDecoder(StringDecoder).decode(schema, arrayOf<Any?>(Utf8("a"), Utf8("b"))) shouldBe setOf("a", "b")
+   }
+
+   test("preserves encounter order") {
+      val schema = Schema.createArray(Schema.create(Schema.Type.STRING))
+      val decoded = SetDecoder(StringDecoder).decode(schema, listOf(Utf8("c"), Utf8("a"), Utf8("b")))
+      decoded.toList() shouldContainExactly listOf("c", "a", "b")
+   }
+
+   test("deduplicates repeated elements") {
+      val schema = Schema.createArray(Schema.create(Schema.Type.STRING))
+      SetDecoder(StringDecoder).decode(schema, listOf(Utf8("x"), Utf8("x"), Utf8("y"))) shouldBe setOf("x", "y")
+   }
+
+   test("empty list yields empty set") {
+      val schema = Schema.createArray(Schema.create(Schema.Type.STRING))
+      SetDecoder(StringDecoder).decode(schema, emptyList<Any?>()) shouldBe emptySet()
+   }
+})


### PR DESCRIPTION
## Summary
Mirror of the recent MapDecoder direct-fill change. \`SetDecoder.decode\` called \`.map { decoder.decode(...) }.toSet()\`, which allocates an intermediate \`ArrayList\` of the decoded elements and immediately throws it away.

Switch to a pre-sized \`LinkedHashSet\` populated in a single forEach. Same encounter-order semantics, one fewer allocation per decode call.

## Test plan
- [x] New SetDecoderTest covers List/Array inputs, encounter-order preservation, deduplication, and the empty case.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)