### PR TITLE
Improve primitive decoder error messages and add coverage

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/primitives.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/primitives.kt
@@ -6,7 +6,7 @@ object ByteDecoder : Decoder<Byte> {
    override fun decode(schema: Schema, value: Any?): Byte {
       return when (value) {
          is Byte -> value
-         else -> error("Unsupported value $value")
+         else -> error("ByteDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -16,7 +16,7 @@ object ShortDecoder : Decoder<Short> {
       return when (value) {
          is Short -> value
          is Byte -> value.toShort()
-         else -> error("Unsupported value $value")
+         else -> error("ShortDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -27,7 +27,7 @@ object IntDecoder : Decoder<Int> {
          is Int -> value
          is Short -> value.toInt()
          is Byte -> value.toInt()
-         else -> error("Unsupported value $value")
+         else -> error("IntDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -39,7 +39,7 @@ object LongDecoder : Decoder<Long> {
          is Int -> value.toLong()
          is Byte -> value.toLong()
          is Short -> value.toLong()
-         else -> error("Unsupported value $value")
+         else -> error("LongDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -49,7 +49,7 @@ object DoubleDecoder : Decoder<Double> {
       return when (value) {
          is Double -> value
          is Float -> value.toDouble()
-         else -> error("Unsupported value $value")
+         else -> error("DoubleDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -58,7 +58,7 @@ object FloatDecoder : Decoder<Float> {
    override fun decode(schema: Schema, value: Any?): Float {
       return when (value) {
          is Float -> value
-         else -> error("Unsupported value $value")
+         else -> error("FloatDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }
@@ -67,7 +67,7 @@ object BooleanDecoder : Decoder<Boolean> {
    override fun decode(schema: Schema, value: Any?): Boolean {
       return when (value) {
          is Boolean -> value
-         else -> error("Unsupported value $value")
+         else -> error("BooleanDecoder cannot decode ${value?.javaClass?.name}: $value")
       }
    }
 }

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/PrimitiveDecodersTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/PrimitiveDecodersTest.kt
@@ -1,0 +1,65 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.apache.avro.Schema
+
+class PrimitiveDecodersTest : FunSpec({
+
+   test("ByteDecoder accepts Byte") {
+      ByteDecoder.decode(Schema.create(Schema.Type.INT), 7.toByte()) shouldBe 7.toByte()
+   }
+
+   test("ByteDecoder rejects Int with a useful message") {
+      val ex = shouldThrow<IllegalStateException> {
+         ByteDecoder.decode(Schema.create(Schema.Type.INT), 1)
+      }
+      ex.message!! shouldContain "ByteDecoder"
+   }
+
+   test("ShortDecoder widens Byte to Short") {
+      ShortDecoder.decode(Schema.create(Schema.Type.INT), 3.toByte()) shouldBe 3.toShort()
+      ShortDecoder.decode(Schema.create(Schema.Type.INT), 3.toShort()) shouldBe 3.toShort()
+   }
+
+   test("IntDecoder widens Byte and Short to Int") {
+      IntDecoder.decode(Schema.create(Schema.Type.INT), 4.toByte()) shouldBe 4
+      IntDecoder.decode(Schema.create(Schema.Type.INT), 4.toShort()) shouldBe 4
+      IntDecoder.decode(Schema.create(Schema.Type.INT), 4) shouldBe 4
+   }
+
+   test("DoubleDecoder widens Float to Double") {
+      DoubleDecoder.decode(Schema.create(Schema.Type.DOUBLE), 1.5f) shouldBe 1.5
+      DoubleDecoder.decode(Schema.create(Schema.Type.DOUBLE), 1.5) shouldBe 1.5
+   }
+
+   test("FloatDecoder accepts Float only") {
+      FloatDecoder.decode(Schema.create(Schema.Type.FLOAT), 2.5f) shouldBe 2.5f
+      shouldThrow<IllegalStateException> {
+         FloatDecoder.decode(Schema.create(Schema.Type.FLOAT), 2.5)
+      }
+   }
+
+   test("BooleanDecoder accepts Boolean") {
+      BooleanDecoder.decode(Schema.create(Schema.Type.BOOLEAN), true) shouldBe true
+      BooleanDecoder.decode(Schema.create(Schema.Type.BOOLEAN), false) shouldBe false
+      val ex = shouldThrow<IllegalStateException> {
+         BooleanDecoder.decode(Schema.create(Schema.Type.BOOLEAN), "true")
+      }
+      ex.message!! shouldContain "BooleanDecoder"
+   }
+
+   test("error messages identify the decoder type") {
+      shouldThrow<IllegalStateException> {
+         IntDecoder.decode(Schema.create(Schema.Type.INT), "x")
+      }.message!! shouldContain "IntDecoder"
+      shouldThrow<IllegalStateException> {
+         LongDecoder.decode(Schema.create(Schema.Type.LONG), "x")
+      }.message!! shouldContain "LongDecoder"
+      shouldThrow<IllegalStateException> {
+         DoubleDecoder.decode(Schema.create(Schema.Type.DOUBLE), "x")
+      }.message!! shouldContain "DoubleDecoder"
+   }
+})


### PR DESCRIPTION
## Summary
Every primitive decoder (\`ByteDecoder\`, \`ShortDecoder\`, \`IntDecoder\`, \`LongDecoder\`, \`DoubleDecoder\`, \`FloatDecoder\`, \`BooleanDecoder\`) fails with the same generic \`Unsupported value \$value\` message, which doesn't say *which* decoder rejected the value. When a wrong type lands in a deeply-nested record, the stack trace is the only way to find the decoder responsible.

Name the decoder and the offending class in each error message. Also add a \`PrimitiveDecodersTest\` covering happy paths, the widening conversions (Byte→Short, Byte/Short→Int, Float→Double), and that the error message identifies the decoder.

## Test plan
- [x] New PrimitiveDecodersTest passes.
- [x] Existing LongDecoderTest still passes.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)