### PR TITLE
Read ByteBuffer via duplicate() in string decoder helper

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
@@ -99,7 +99,7 @@ object ByteStringDecoder : Decoder<String> {
 
 private fun ByteBuffer.readRemainingBytes(): ByteArray {
    val bytes = ByteArray(remaining())
-   get(bytes)
+   duplicate().get(bytes)
    return bytes
 }
 

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringDecoderBufferPositionTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringDecoderBufferPositionTest.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import java.nio.ByteBuffer
+
+class StringDecoderBufferPositionTest : FunSpec({
+
+   test("StringDecoder reads only remaining bytes from a positioned ByteBuffer") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap("xxhello".encodeToByteArray())
+      buffer.position(2)
+      StringDecoder.decode(schema, buffer) shouldBe "hello"
+   }
+
+   test("StringDecoder does not mutate the source buffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap("xxhello".encodeToByteArray())
+      buffer.position(2)
+      StringDecoder.decode(schema, buffer)
+      buffer.position() shouldBe 2
+      buffer.remaining() shouldBe 5
+   }
+
+   test("UTF8Decoder does not mutate the source buffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap("..world".encodeToByteArray())
+      buffer.position(2)
+      UTF8Decoder.decode(schema, buffer).toString() shouldBe "world"
+      buffer.position() shouldBe 2
+   }
+
+   test("ByteStringDecoder does not mutate the source buffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val buffer = ByteBuffer.wrap("__foo".encodeToByteArray())
+      buffer.position(2)
+      ByteStringDecoder.decode(schema, buffer) shouldBe "foo"
+      buffer.position() shouldBe 2
+   }
+})


### PR DESCRIPTION
## Summary
Sibling of #36 on the string-decoder side. The private \`ByteBuffer.readRemainingBytes()\` helper in \`strings.kt\` — used by \`StringDecoder\`, \`UTF8Decoder\` and \`ByteStringDecoder\` — called \`get(bytes)\` directly on the input buffer, mutating its position.

Use \`duplicate().get(...)\` so the source buffer is left untouched.

## Test plan
- [x] New StringDecoderBufferPositionTest covers all three affected decoders, including the position-not-mutated assertions.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)