### PR TITLE
Zero-pad to fixedSize in FixedStringEncoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
@@ -68,6 +68,9 @@ object FixedStringEncoder : Encoder<String> {
       val bytes = value.encodeToByteArray()
       if (bytes.size > schema.fixedSize)
          error("Cannot write string with ${bytes.size} bytes to fixed type of size ${schema.fixedSize}")
-      return instance.createFixed(null, bytes, schema)
+      val padded = if (bytes.size == schema.fixedSize) bytes else ByteArray(schema.fixedSize).also {
+         System.arraycopy(bytes, 0, it, 0, bytes.size)
+      }
+      return instance.createFixed(null, padded, schema)
    }
 }


### PR DESCRIPTION
## Summary
\`FixedStringEncoder\` was inconsistent with \`FixedByteBufferEncoder\` / \`FixedByteArrayEncoder\` (#31, #32). The byte variants zero-pad to \`schema.fixedSize\` when the input is shorter; the string encoder passed the raw encoded bytes through, producing a \`GenericFixed\` whose backing array did not match the schema size.

Pre-allocate a \`ByteArray(schema.fixedSize)\`, copy the encoded bytes into it, leave the trailing bytes zero.

## Test plan
- [x] Existing StringEncoderTest still passes.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)