### PR TITLE
Pass a duplicate() to BigDecimalBytesDecoder converter

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
@@ -19,7 +19,7 @@ object BigDecimalBytesDecoder : Decoder<BigDecimal> {
       require(schema.type == Schema.Type.BYTES)
       val logical = schema.logicalType as LogicalTypes.Decimal
       return when (value) {
-         is ByteBuffer -> converter.fromBytes(value, schema, logical)
+         is ByteBuffer -> converter.fromBytes(value.duplicate(), schema, logical)
          is ByteArray -> converter.fromBytes(ByteBuffer.wrap(value), schema, logical)
          else -> error("Unsupported value for BigDecimal bytes decoder: $value")
       }


### PR DESCRIPTION
## Summary
\`BigDecimalBytesDecoder\` passed the caller's \`ByteBuffer\` straight into Avro's \`Conversions.DecimalConversion.fromBytes\`, which reads from the buffer and advances its position. The buffer was mutated by the decode, breaking callers that read the buffer again afterwards.

Pass \`value.duplicate()\` so the source buffer is untouched, matching the pattern landed for the byte decoders in #36 and the string decoder helper in #40.

## Test plan
- [x] Existing BigDecimalDecoderTest still passes (the positioned-buffer case is already covered, only the position-not-mutated assertion was missing — adding it would expose the bug; this PR fixes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)