### PR TITLE
Hoist first type-argument in Encoder/Decoder dispatch

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -30,6 +30,7 @@ fun interface Decoder<T> {
       @Suppress("UNCHECKED_CAST")
       fun decoderFor(type: KType,   schema: Schema): Decoder<*> {
          val nonNullSchema = if (schema.isUnion) schema.unionNonNullComponent() else schema
+         val firstArgType = type.arguments.firstOrNull()?.type
          val decoder: Decoder<*> = when (val classifier = type.classifier) {
             String::class if schema.type == Schema.Type.STRING -> StringTypeDecoder
             String::class -> StringDecoder
@@ -43,26 +44,26 @@ fun interface Decoder<T> {
             BigDecimal::class -> BigDecimalStringDecoder
             ByteArray::class -> ByteArrayDecoder
             ByteBuffer::class -> ByteBufferDecoder
-            List::class if type.arguments.first().type == typeOf<Long>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Int>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Short>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Byte>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Boolean>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Double>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<Float>() -> PassthroughListDecoder
-            List::class if type.arguments.first().type == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> ListDecoder(StringTypeDecoder)
-            List::class -> ListDecoder(decoderFor(type.arguments.first().type!!, nonNullSchema.elementType))
+            List::class if firstArgType == typeOf<Long>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Int>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Short>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Byte>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Boolean>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Double>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<Float>() -> PassthroughListDecoder
+            List::class if firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> ListDecoder(StringTypeDecoder)
+            List::class -> ListDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
             LongArray::class -> LongArrayDecoder(LongDecoder)
             IntArray::class -> IntArrayDecoder(IntDecoder)
-            Set::class if type.arguments.first().type == typeOf<Long>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Int>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Short>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Byte>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Boolean>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Double>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<Float>() -> PassthroughSetDecoder
-            Set::class if type.arguments.first().type == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> SetDecoder(StringTypeDecoder)
-            Set::class -> SetDecoder(decoderFor(type.arguments.first().type!!, nonNullSchema.elementType))
+            Set::class if firstArgType == typeOf<Long>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Int>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Short>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Byte>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Boolean>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Double>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<Float>() -> PassthroughSetDecoder
+            Set::class if firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> SetDecoder(StringTypeDecoder)
+            Set::class -> SetDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
             Map::class -> MapDecoder(decoderFor(type.arguments[1].type!!, nonNullSchema.valueType))
             LocalTime::class -> LocalTimeDecoder
             LocalDateTime::class -> LocalDateTimeDecoder

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -30,7 +30,6 @@ fun interface Decoder<T> {
       @Suppress("UNCHECKED_CAST")
       fun decoderFor(type: KType,   schema: Schema): Decoder<*> {
          val nonNullSchema = if (schema.isUnion) schema.unionNonNullComponent() else schema
-         val firstArgType = type.arguments.firstOrNull()?.type
          val decoder: Decoder<*> = when (val classifier = type.classifier) {
             String::class if schema.type == Schema.Type.STRING -> StringTypeDecoder
             String::class -> StringDecoder
@@ -44,26 +43,36 @@ fun interface Decoder<T> {
             BigDecimal::class -> BigDecimalStringDecoder
             ByteArray::class -> ByteArrayDecoder
             ByteBuffer::class -> ByteBufferDecoder
-            List::class if firstArgType == typeOf<Long>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Int>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Short>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Byte>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Boolean>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Double>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<Float>() -> PassthroughListDecoder
-            List::class if firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> ListDecoder(StringTypeDecoder)
-            List::class -> ListDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
+            List::class -> {
+               val firstArgType = type.arguments.firstOrNull()?.type
+               when {
+                  firstArgType == typeOf<Long>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Int>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Short>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Byte>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Boolean>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Double>() -> PassthroughListDecoder
+                  firstArgType == typeOf<Float>() -> PassthroughListDecoder
+                  firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> ListDecoder(StringTypeDecoder)
+                  else -> ListDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
+               }
+            }
             LongArray::class -> LongArrayDecoder(LongDecoder)
             IntArray::class -> IntArrayDecoder(IntDecoder)
-            Set::class if firstArgType == typeOf<Long>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Int>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Short>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Byte>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Boolean>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Double>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<Float>() -> PassthroughSetDecoder
-            Set::class if firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> SetDecoder(StringTypeDecoder)
-            Set::class -> SetDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
+            Set::class -> {
+               val firstArgType = type.arguments.firstOrNull()?.type
+               when {
+                  firstArgType == typeOf<Long>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Int>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Short>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Byte>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Boolean>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Double>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<Float>() -> PassthroughSetDecoder
+                  firstArgType == typeOf<String>() && nonNullSchema.elementType.type == Schema.Type.STRING -> SetDecoder(StringTypeDecoder)
+                  else -> SetDecoder(decoderFor(firstArgType!!, nonNullSchema.elementType))
+               }
+            }
             Map::class -> MapDecoder(decoderFor(type.arguments[1].type!!, nonNullSchema.valueType))
             LocalTime::class -> LocalTimeDecoder
             LocalDateTime::class -> LocalDateTimeDecoder

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -38,7 +38,6 @@ fun interface Encoder<T> {
       fun encoderFor(type: KType, schema: Schema): Encoder<*> {
          if (type.isMarkedNullable) require(schema.isUnion) { "Require UNION for fields marked nullable" }
          val nonNullSchema = if (schema.isUnion) schema.unionNonNullComponent() else schema
-         val firstArgType = type.arguments.firstOrNull()?.type
          val encoder: Encoder<*> = when (val classifier = type.classifier) {
             String::class if nonNullSchema.type == Schema.Type.STRING -> JavaStringEncoder
             String::class if nonNullSchema.type == Schema.Type.BYTES -> ByteStringEncoder
@@ -54,27 +53,37 @@ fun interface Encoder<T> {
             BigDecimal::class -> BigDecimalStringEncoder
             ByteBuffer::class -> ByteBufferEncoder
             ByteArray::class -> ByteArrayEncoder
-            List::class if firstArgType == typeOf<Long>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Int>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Short>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Byte>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Boolean>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<String>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Double>() -> PassThroughListEncoder
-            List::class if firstArgType == typeOf<Float>() -> PassThroughListEncoder
-            List::class -> ListEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
+            List::class -> {
+               val firstArgType = type.arguments.firstOrNull()?.type
+               when {
+                  firstArgType == typeOf<Long>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Int>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Short>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Byte>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Boolean>() -> PassThroughListEncoder
+                  firstArgType == typeOf<String>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Double>() -> PassThroughListEncoder
+                  firstArgType == typeOf<Float>() -> PassThroughListEncoder
+                  else -> ListEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
+               }
+            }
 
             LongArray::class -> LongArrayEncoder()
             IntArray::class -> IntArrayEncoder()
-            Set::class if firstArgType == typeOf<Long>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Int>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Short>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Byte>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Boolean>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<String>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Double>() -> PassThroughSetEncoder
-            Set::class if firstArgType == typeOf<Float>() -> PassThroughSetEncoder
-            Set::class -> SetEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
+            Set::class -> {
+               val firstArgType = type.arguments.firstOrNull()?.type
+               when {
+                  firstArgType == typeOf<Long>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Int>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Short>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Byte>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Boolean>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<String>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Double>() -> PassThroughSetEncoder
+                  firstArgType == typeOf<Float>() -> PassThroughSetEncoder
+                  else -> SetEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
+               }
+            }
 
             Map::class -> MapEncoder(encoderFor(type.arguments[1].type!!, nonNullSchema.valueType))
 

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -38,6 +38,7 @@ fun interface Encoder<T> {
       fun encoderFor(type: KType, schema: Schema): Encoder<*> {
          if (type.isMarkedNullable) require(schema.isUnion) { "Require UNION for fields marked nullable" }
          val nonNullSchema = if (schema.isUnion) schema.unionNonNullComponent() else schema
+         val firstArgType = type.arguments.firstOrNull()?.type
          val encoder: Encoder<*> = when (val classifier = type.classifier) {
             String::class if nonNullSchema.type == Schema.Type.STRING -> JavaStringEncoder
             String::class if nonNullSchema.type == Schema.Type.BYTES -> ByteStringEncoder
@@ -53,44 +54,29 @@ fun interface Encoder<T> {
             BigDecimal::class -> BigDecimalStringEncoder
             ByteBuffer::class -> ByteBufferEncoder
             ByteArray::class -> ByteArrayEncoder
-            List::class if type.arguments.first().type == typeOf<Long>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Int>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Short>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Byte>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Boolean>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<String>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Double>() -> PassThroughListEncoder
-            List::class if type.arguments.first().type == typeOf<Float>() -> PassThroughListEncoder
-            List::class -> ListEncoder(
-               encoderFor(
-                  type.arguments.first().type!!,
-                  nonNullSchema.elementType
-               )
-            )
+            List::class if firstArgType == typeOf<Long>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Int>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Short>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Byte>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Boolean>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<String>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Double>() -> PassThroughListEncoder
+            List::class if firstArgType == typeOf<Float>() -> PassThroughListEncoder
+            List::class -> ListEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
 
             LongArray::class -> LongArrayEncoder()
             IntArray::class -> IntArrayEncoder()
-            Set::class if type.arguments.first().type == typeOf<Long>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Int>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Short>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Byte>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Boolean>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<String>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Double>() -> PassThroughSetEncoder
-            Set::class if type.arguments.first().type == typeOf<Float>() -> PassThroughSetEncoder
-            Set::class -> SetEncoder(
-               encoderFor(
-                  type.arguments.first().type!!,
-                  nonNullSchema.elementType
-               )
-            )
+            Set::class if firstArgType == typeOf<Long>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Int>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Short>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Byte>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Boolean>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<String>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Double>() -> PassThroughSetEncoder
+            Set::class if firstArgType == typeOf<Float>() -> PassThroughSetEncoder
+            Set::class -> SetEncoder(encoderFor(firstArgType!!, nonNullSchema.elementType))
 
-            Map::class -> MapEncoder(
-               encoderFor(
-                  type.arguments[1].type!!,
-                  nonNullSchema.valueType
-               )
-            )
+            Map::class -> MapEncoder(encoderFor(type.arguments[1].type!!, nonNullSchema.valueType))
 
             LocalTime::class -> LocalTimeEncoder
             LocalDateTime::class -> LocalDateTimeEncoder


### PR DESCRIPTION
## Summary
\`Encoder.encoderFor\` and \`Decoder.decoderFor\` both evaluated \`type.arguments.first().type\` up to nine times per List/Set dispatch — once per pass-through guard plus the recursive call. Each evaluation walks Kotlin reflection and allocates a new \`KType\` wrapper.

Hoist into a single \`firstArgType\` local. Same semantics. Cheaper for the per-class one-shot lookup, and visually shorter.

## Test plan
- [x] \`./gradlew :centurion-avro:test\` is green (all encoder/decoder dispatch paths exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)