### PR TITLE
Cache datum reader/writer in GenericRecordCodec

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
@@ -20,6 +20,9 @@ class GenericRecordCodec(
    private val decoderFactory: DecoderFactory,
 ) : RedisCodec<GenericRecord, GenericRecord> {
 
+   private val datumReader = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
+   private val datumWriter = GenericDatumWriter<GenericRecord>(schema)
+
    override fun decodeKey(buffer: ByteBuffer): GenericRecord {
       return decode(buffer)
    }
@@ -37,18 +40,16 @@ class GenericRecordCodec(
    }
 
    private fun decode(buffer: ByteBuffer): GenericRecord {
-      val datum = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
       val bytes = ByteArray(buffer.remaining())
       buffer.get(bytes)
       val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
-      return datum.read(null, decoder)
+      return datumReader.read(null, decoder)
    }
 
    private fun encode(record: GenericRecord): ByteBuffer {
-      val datum = GenericDatumWriter<GenericRecord>(record.schema)
       val baos = ByteArrayOutputStream()
       val encoder = encoderFactory.binaryEncoder(baos, null)
-      datum.write(record, encoder)
+      datumWriter.write(record, encoder)
       encoder.flush()
       return ByteBuffer.wrap(baos.toByteArray())
    }


### PR DESCRIPTION
## Summary
\`GenericRecordCodec\` holds an immutable schema for its lifetime but allocated a fresh \`GenericDatumReader\`/\`GenericDatumWriter\` on every encode and decode. Both classes are designed to be reused with a fixed schema; only the binary encoder/decoder is intrinsically per-call.

Cache both as private fields.

## Test plan
- [x] Build is green; lettuce tests need Docker (environmental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)