### PR TITLE
Cache datum reader/writer in ReflectionDataClassCodec

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
@@ -26,6 +26,8 @@ class ReflectionDataClassCodec<T : Any>(
    private val schema = ReflectionSchemaBuilder().schema(kclass)
    private val encoder = ReflectionRecordEncoder(schema, kclass)
    private val decoder = ReflectionRecordDecoder(schema, kclass)
+   private val datumReader = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
+   private val datumWriter = GenericDatumWriter<GenericRecord>(schema)
 
    override fun decodeKey(buffer: ByteBuffer): T {
       return decoder.decode(schema, read(buffer))
@@ -44,18 +46,16 @@ class ReflectionDataClassCodec<T : Any>(
    }
 
    private fun read(buffer: ByteBuffer): GenericRecord {
-      val datum = GenericDatumReader<GenericRecord>(/* writer = */ schema, /* reader = */ schema)
       val bytes = ByteArray(buffer.remaining())
       buffer.get(bytes)
       val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
-      return datum.read(null, decoder)
+      return datumReader.read(null, decoder)
    }
 
    private fun write(record: GenericRecord): ByteBuffer {
-      val datum = GenericDatumWriter<GenericRecord>(record.schema)
       val baos = ByteArrayOutputStream()
       val encoder = encoderFactory.binaryEncoder(baos, null)
-      datum.write(record, encoder)
+      datumWriter.write(record, encoder)
       encoder.flush()
       return ByteBuffer.wrap(baos.toByteArray())
    }


### PR DESCRIPTION
## Summary
Same change as the sibling \`GenericRecordCodec\` PR (#47). \`ReflectionDataClassCodec\` allocated a fresh \`GenericDatumReader\`/\`GenericDatumWriter\` on every encode/decode despite its schema being fixed for the codec's lifetime.

Cache both as private fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)