### PR TITLE
Include the schema in encoderFor/decoderFor dispatch errors

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -69,7 +69,7 @@ fun interface Decoder<T> {
             Instant::class -> InstantDecoder
             is KClass<*> if classifier.java.isEnum -> EnumDecoder(classifier as KClass<out Enum<*>>)
             is KClass<*> if classifier.isData -> ReflectionRecordDecoder(schema, classifier)
-            else -> error("Unsupported type $type")
+            else -> error("No Decoder available for type $type with schema ${schema.type} ($schema)")
          }
          return if (type.isMarkedNullable) NullDecoder(decoder) else decoder
       }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -97,7 +97,7 @@ fun interface Encoder<T> {
             Instant::class -> InstantEncoder
             is KClass<*> if classifier.java.isEnum -> EnumEncoder()
             is KClass<*> if classifier.isData -> ReflectionRecordEncoder(schema, classifier)
-            else -> error("Unsupported type $type")
+            else -> error("No Encoder available for type $type with schema ${schema.type} ($schema)")
          }
          return if (type.isMarkedNullable) NullEncoder(encoder) else encoder
       }


### PR DESCRIPTION
## Summary
Both \`encoderFor\` and \`decoderFor\` reported \`Unsupported type \$type\` when no branch matched. The real diagnostic is the mismatch between the Kotlin type and the Avro schema — include the schema (type and full schema) in the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)