### PR TITLE
Identify the value class in StringDecoder/UTF8Decoder errors

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
@@ -19,7 +19,7 @@ object StringDecoder : Decoder<String> {
          is ByteArray -> Utf8(value).toString()
          is ByteBuffer -> Utf8(value.readRemainingBytes()).toString()
          is GenericFixed -> Utf8(value.bytes()).toString()
-         else -> error("Unsupported type $value")
+         else -> error("Cannot decode ${value?.javaClass?.name} as String: $value")
       }
    }
 }
@@ -55,7 +55,7 @@ object UTF8Decoder : Decoder<Utf8> {
          is ByteArray -> Utf8(value)
          is ByteBuffer -> Utf8(value.readRemainingBytes())
          is GenericFixed -> Utf8(value.bytes())
-         else -> error("Unsupported type $value")
+         else -> error("Cannot decode ${value?.javaClass?.name} as Utf8: $value")
       }
    }
 }


### PR DESCRIPTION
## Summary
\`StringDecoder\` and \`UTF8Decoder\` both reported \`Unsupported type \$value\` on unexpected inputs. The value's class is what you need to debug a coercion failure — include it, and tag the error with the decoder name so the message identifies itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)