### PR TITLE
Include enum class and valid symbols in EnumDecoder error

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/enums.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/enums.kt
@@ -26,6 +26,6 @@ class EnumDecoder<T : Enum<T>>(kclass: KClass<T>) : Decoder<T> {
          is Utf8 -> value.toString()
          else -> error("Unsupported enum container $value")
       }
-      return map[symbol] ?: error("Unknown symbol $value")
+      return map[symbol] ?: error("Unknown enum symbol \"$symbol\" for ${j.name}; valid values are ${map.keys}")
    }
 }


### PR DESCRIPTION
## Summary
\`EnumDecoder\` reported just \`Unknown symbol \$value\` on a missing symbol. Include the enum class name and the set of valid symbols — both are typically what you need to diagnose a producer/consumer schema mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)