### PR TITLE
Drop dead Utf8 branch in BigDecimalStringDecoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigdecimal.kt
@@ -34,7 +34,6 @@ object BigDecimalStringDecoder : Decoder<BigDecimal> {
       require(schema.type == Schema.Type.STRING)
       return when (value) {
          is CharSequence -> BigDecimal(value.toString())
-         is Utf8 -> BigDecimal(value.toString())
          else -> error("Unsupported value for BigDecimal string decoder: $value")
       }
    }


### PR DESCRIPTION
## Summary
\`org.apache.avro.util.Utf8\` implements \`CharSequence\`, so the \`is Utf8\` arm in the when was unreachable — the preceding \`is CharSequence\` already covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)