### PR TITLE
Add tests for UUID encoders

### DIFF
--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/UUIDEncoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/UUIDEncoderTest.kt
@@ -1,0 +1,20 @@
+package com.sksamuel.centurion.avro.encoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
+import java.util.UUID
+
+class UUIDEncoderTest : FunSpec({
+
+   val uuid: UUID = UUID.fromString("c0a80101-1d3e-11ed-861d-0242ac120002")
+
+   test("Utf8UUIDEncoder encodes as a Utf8") {
+      Utf8UUIDEncoder.encode(Schema.create(Schema.Type.STRING), uuid) shouldBe Utf8(uuid.toString())
+   }
+
+   test("JavaStringUUIDEncoder encodes as a Java String") {
+      JavaStringUUIDEncoder.encode(Schema.create(Schema.Type.STRING), uuid) shouldBe uuid.toString()
+   }
+})


### PR DESCRIPTION
## Summary
\`Utf8UUIDEncoder\` and \`JavaStringUUIDEncoder\` had no direct tests. Add minimal coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)