### PR TITLE
Skip the union scan when value is null in NullEncoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
@@ -10,8 +10,8 @@ class NullEncoder<T>(private val encoder: Encoder<T>) : Encoder<T?> {
       // nullables must be encoded with a union of 2 elements
       require(schema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
       require(schema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
+      if (value == null) return null
       val notNullSchema = schema.types.first { !it.isNullable }
-      val notNullEncoder = encoder
-      return if (value == null) null else notNullEncoder.encode(notNullSchema, value)
+      return encoder.encode(notNullSchema, value)
    }
 }


### PR DESCRIPTION
## Summary
Two small \`NullEncoder\` cleanups:

- Drop the dead \`val notNullEncoder = encoder\` rename.
- Short-circuit the null path before scanning \`schema.types.first { !it.isNullable }\` — for null values the scan result is discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)