### PR TITLE
test: add PassThroughCollectionEncodersTest

### DIFF
--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/PassThroughCollectionEncodersTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/PassThroughCollectionEncodersTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.centurion.avro.encoders
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import org.apache.avro.Schema
+
+class PassThroughCollectionEncodersTest : FunSpec({
+
+   val arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING))
+
+   test("PassThroughListEncoder returns the input list as-is") {
+      val input = listOf<Any?>("a", 1, null)
+      val encoded = PassThroughListEncoder.encode(arraySchema, input)
+      encoded shouldBeSameInstanceAs input
+   }
+
+   test("PassThroughListEncoder accepts an empty list") {
+      PassThroughListEncoder.encode(arraySchema, emptyList<Any?>()) shouldBe emptyList()
+   }
+
+   test("PassThroughListEncoder requires an ARRAY schema") {
+      shouldThrow<IllegalArgumentException> {
+         PassThroughListEncoder.encode(Schema.create(Schema.Type.STRING), listOf<Any?>("a"))
+      }
+   }
+
+   test("PassThroughSetEncoder returns the set as an equivalent List") {
+      val input = setOf<Any?>("a", "b")
+      val encoded = PassThroughSetEncoder.encode(arraySchema, input)
+      encoded.toSet() shouldBe input
+   }
+
+   test("PassThroughSetEncoder accepts an empty set") {
+      PassThroughSetEncoder.encode(arraySchema, emptySet<Any?>()) shouldBe emptyList()
+   }
+
+   test("PassThroughSetEncoder requires an ARRAY schema") {
+      shouldThrow<IllegalArgumentException> {
+         PassThroughSetEncoder.encode(Schema.create(Schema.Type.STRING), setOf<Any?>("a"))
+      }
+   }
+})


### PR DESCRIPTION
## Summary
- Tests `PassThroughListEncoder` (returns the same list instance) and `PassThroughSetEncoder` (converts to an equivalent list).
- Covers empty inputs and the ARRAY-schema guard.

## Test plan
- [x] `./gradlew :centurion-avro:test --tests PassThroughCollectionEncodersTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)