### PR TITLE
test: add StringTypeDecoderTest and CharSequenceDecoderTest

### DIFF
--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/CharSequenceDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/CharSequenceDecoderTest.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.Utf8
+import java.nio.ByteBuffer
+
+class CharSequenceDecoderTest : FunSpec({
+
+   test("CharSequenceDecoder decodes a Kotlin String") {
+      CharSequenceDecoder.decode(Schema.create(Schema.Type.STRING), "hello") shouldBe "hello"
+   }
+
+   test("CharSequenceDecoder decodes a Utf8") {
+      CharSequenceDecoder.decode(Schema.create(Schema.Type.STRING), Utf8("world")) shouldBe "world"
+   }
+
+   test("CharSequenceDecoder decodes a ByteArray") {
+      CharSequenceDecoder.decode(Schema.create(Schema.Type.BYTES), "abc".encodeToByteArray()) shouldBe "abc"
+   }
+
+   test("CharSequenceDecoder decodes a ByteBuffer") {
+      CharSequenceDecoder.decode(Schema.create(Schema.Type.BYTES), ByteBuffer.wrap("def".encodeToByteArray())) shouldBe "def"
+   }
+
+   test("CharSequenceDecoder decodes a GenericFixed") {
+      val schema = SchemaBuilder.builder().fixed("f").size(3)
+      val fixed = GenericData.get().createFixed(null, "ghi".encodeToByteArray(), schema) as GenericData.Fixed
+      CharSequenceDecoder.decode(schema, fixed) shouldBe "ghi"
+   }
+
+   test("CharSequenceDecoder rejects an unsupported value") {
+      shouldThrow<IllegalStateException> {
+         CharSequenceDecoder.decode(Schema.create(Schema.Type.STRING), 12345)
+      }
+   }
+})

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringTypeDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/StringTypeDecoderTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.centurion.avro.decoders
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
+
+class StringTypeDecoderTest : FunSpec({
+
+   val stringSchema = Schema.create(Schema.Type.STRING)
+
+   test("StringTypeDecoder decodes a Kotlin String") {
+      StringTypeDecoder.decode(stringSchema, "hello") shouldBe "hello"
+   }
+
+   test("StringTypeDecoder decodes a Utf8 via toString") {
+      StringTypeDecoder.decode(stringSchema, Utf8("world")) shouldBe "world"
+   }
+
+   test("StringTypeDecoder calls toString on arbitrary CharSequence input") {
+      val cs: CharSequence = StringBuilder("abc")
+      StringTypeDecoder.decode(stringSchema, cs) shouldBe "abc"
+   }
+
+   test("StringTypeDecoder calls toString on non-CharSequence input") {
+      StringTypeDecoder.decode(stringSchema, 12345) shouldBe "12345"
+   }
+})


### PR DESCRIPTION
## Summary
- Adds dedicated tests for `StringTypeDecoder` and `CharSequenceDecoder`.
- `StringTypeDecoder` is exercised across `String`, `Utf8`, an arbitrary `CharSequence` (`StringBuilder`), and a non-`CharSequence` value (relying on the documented `value.toString()` behaviour).
- `CharSequenceDecoder` is exercised across `String`, `Utf8`, `ByteArray`, `ByteBuffer`, `GenericFixed`, and rejects an unsupported value.

Neither decoder had dedicated tests prior to this PR.

## Test plan
- [x] `./gradlew :centurion-avro:test --tests StringTypeDecoderTest --tests CharSequenceDecoderTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)