### PR TITLE
perf: hoist temporal Conversion singletons and cache logicalType

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
@@ -19,6 +19,13 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
+private val LOCAL_TIMESTAMP_MILLIS_CONVERSION = LocalTimestampMillisConversion()
+private val LOCAL_TIMESTAMP_MICROS_CONVERSION = LocalTimestampMicrosConversion()
+private val TIME_MILLIS_CONVERSION = TimeMillisConversion()
+private val TIME_MICROS_CONVERSION = TimeMicrosConversion()
+private val TIMESTAMP_MILLIS_CONVERSION = TimestampMillisConversion()
+private val TIMESTAMP_MICROS_CONVERSION = TimestampMicrosConversion()
+
 /**
  * [Decoder] for [Instant] which supports [LogicalTypes.TimestampMillis], [LogicalTypes.TimestampMicros] and Longs.
  */
@@ -27,8 +34,8 @@ object InstantDecoder : Decoder<Instant> {
       return when (value) {
          is Long -> {
             when (val logicalType = schema.logicalType) {
-               is LogicalTypes.TimestampMillis -> TimestampMillisConversion().fromLong(value, schema, logicalType)
-               is LogicalTypes.TimestampMicros -> TimestampMicrosConversion().fromLong(value, schema, logicalType)
+               is LogicalTypes.TimestampMillis -> TIMESTAMP_MILLIS_CONVERSION.fromLong(value, schema, logicalType)
+               is LogicalTypes.TimestampMicros -> TIMESTAMP_MICROS_CONVERSION.fromLong(value, schema, logicalType)
                null -> Instant.ofEpochMilli(value)
                else -> error("Unsupported schema for Instant: $schema")
             }
@@ -47,7 +54,7 @@ object LocalTimeDecoder : Decoder<LocalTime> {
       return when (value) {
          is Long -> {
             when (val logicalType = schema.logicalType) {
-               is TimeMicros -> TimeMicrosConversion().fromLong(value, schema, logicalType)
+               is TimeMicros -> TIME_MICROS_CONVERSION.fromLong(value, schema, logicalType)
                null -> LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(value))
                else -> error("Unsupported schema for Instant: $schema")
             }
@@ -55,7 +62,7 @@ object LocalTimeDecoder : Decoder<LocalTime> {
 
          is Int -> {
             when (val logicalType = schema.logicalType) {
-               is TimeMillis -> TimeMillisConversion().fromInt(value, schema, logicalType)
+               is TimeMillis -> TIME_MILLIS_CONVERSION.fromInt(value, schema, logicalType)
                else -> error("Unsupported schema for Instant: $schema")
             }
          }
@@ -75,8 +82,8 @@ object LocalDateTimeDecoder : Decoder<LocalDateTime> {
       return when (value) {
          is Long -> {
             when (val logicalType = schema.logicalType) {
-               is LocalTimestampMillis -> LocalTimestampMillisConversion().fromLong(value, schema, logicalType)
-               is LocalTimestampMicros -> LocalTimestampMicrosConversion().fromLong(value, schema, logicalType)
+               is LocalTimestampMillis -> LOCAL_TIMESTAMP_MILLIS_CONVERSION.fromLong(value, schema, logicalType)
+               is LocalTimestampMicros -> LOCAL_TIMESTAMP_MICROS_CONVERSION.fromLong(value, schema, logicalType)
                null -> LocalDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC)
                else -> error("Unsupported schema for LocalDateTime: $schema")
             }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/temporals.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/temporals.kt
@@ -20,14 +20,22 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
+private val LOCAL_TIMESTAMP_MILLIS_CONVERSION = LocalTimestampMillisConversion()
+private val LOCAL_TIMESTAMP_MICROS_CONVERSION = LocalTimestampMicrosConversion()
+private val TIME_MILLIS_CONVERSION = TimeMillisConversion()
+private val TIME_MICROS_CONVERSION = TimeMicrosConversion()
+private val TIMESTAMP_MILLIS_CONVERSION = TimestampMillisConversion()
+private val TIMESTAMP_MICROS_CONVERSION = TimestampMicrosConversion()
+
 object LocalDateTimeEncoder : Encoder<LocalDateTime> {
    override fun encode(schema: Schema, value: LocalDateTime): Any? {
+      val logicalType = schema.logicalType
       return when {
-         schema.logicalType is LocalTimestampMillis ->
-            LocalTimestampMillisConversion().toLong(value, schema, schema.logicalType)
+         logicalType is LocalTimestampMillis ->
+            LOCAL_TIMESTAMP_MILLIS_CONVERSION.toLong(value, schema, logicalType)
 
-         schema.logicalType is LocalTimestampMicros ->
-            LocalTimestampMicrosConversion().toLong(value, schema, schema.logicalType)
+         logicalType is LocalTimestampMicros ->
+            LOCAL_TIMESTAMP_MICROS_CONVERSION.toLong(value, schema, logicalType)
 
          schema.type == Schema.Type.LONG ->
             value.toInstant(ZoneOffset.UTC).toEpochMilli()
@@ -39,12 +47,13 @@ object LocalDateTimeEncoder : Encoder<LocalDateTime> {
 
 object LocalTimeEncoder : Encoder<LocalTime> {
    override fun encode(schema: Schema, value: LocalTime): Any? {
+      val logicalType = schema.logicalType
       return when {
-         schema.logicalType is TimeMillis ->
-            TimeMillisConversion().toInt(value, schema, schema.logicalType)
+         logicalType is TimeMillis ->
+            TIME_MILLIS_CONVERSION.toInt(value, schema, logicalType)
 
-         schema.logicalType is TimeMicros ->
-            TimeMicrosConversion().toLong(value, schema, schema.logicalType)
+         logicalType is TimeMicros ->
+            TIME_MICROS_CONVERSION.toLong(value, schema, logicalType)
 
          schema.type == Schema.Type.INT ->
             TimeUnit.NANOSECONDS.toMillis(value.toNanoOfDay())
@@ -59,12 +68,13 @@ object LocalTimeEncoder : Encoder<LocalTime> {
  */
 object InstantEncoder : Encoder<Instant> {
    override fun encode(schema: Schema, value: Instant): Any? {
+      val logicalType = schema.logicalType
       return when {
-         schema.logicalType is TimestampMillis ->
-            TimestampMillisConversion().toLong(value, schema, schema.logicalType)
+         logicalType is TimestampMillis ->
+            TIMESTAMP_MILLIS_CONVERSION.toLong(value, schema, logicalType)
 
-         schema.logicalType is TimestampMicros ->
-            TimestampMicrosConversion().toLong(value, schema, schema.logicalType)
+         logicalType is TimestampMicros ->
+            TIMESTAMP_MICROS_CONVERSION.toLong(value, schema, logicalType)
 
          schema.type == Schema.Type.LONG -> value.toEpochMilli()
          else -> error("Unsupported schema for LocalDateTime: $schema")


### PR DESCRIPTION
## Summary
- `TimestampMillisConversion`, `TimestampMicrosConversion`, `LocalTimestampMillisConversion`, `LocalTimestampMicrosConversion`, `TimeMillisConversion`, `TimeMicrosConversion` were being instantiated on every encode/decode call. They're stateless — hoisted into private file-level vals so they allocate once.
- While in there, cache `schema.logicalType` in a local: previously it was read twice per call (once for the `is X` pattern check, once when passed into `fromLong`/`toLong`).

## Impact
- One fewer Conversion allocation per temporal field, per record, on both the encode and decode side.
- Tightens the inner `when` branches.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)