### PR TITLE
perf: NullEncoder/NullDecoder direct indexed union scan

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/nullable.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/nullable.kt
@@ -6,11 +6,14 @@ class NullDecoder<T>(private val decoder: Decoder<T>) : Decoder<T?> {
    override fun decode(schema: Schema, value: Any?): T? {
       // nullables must be encoded with a union of 2 elements, where null is the first type
       require(schema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
-      require(schema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
-      val nullableType = schema.types.firstOrNull { !it.isNullable }
-         ?: error("One of the elements of a nullable union must not be null")
-      return if (value == null) null else {
-         decoder.decode(nullableType, value)
+      val types = schema.types
+      require(types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
+      if (value == null) return null
+      val nonNullType = when {
+         types[0].type == Schema.Type.NULL -> types[1]
+         types[1].type == Schema.Type.NULL -> types[0]
+         else -> error("One of the elements of a nullable union must not be null")
       }
+      return decoder.decode(nonNullType, value)
    }
 }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
@@ -9,9 +9,10 @@ class NullEncoder<T>(private val encoder: Encoder<T>) : Encoder<T?> {
    override fun encode(schema: Schema, value: T?): Any? {
       // nullables must be encoded with a union of 2 elements
       require(schema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
-      require(schema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
+      val types = schema.types
+      require(types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
       if (value == null) return null
-      val notNullSchema = schema.types.first { !it.isNullable }
+      val notNullSchema = if (types[0].type == Schema.Type.NULL) types[1] else types[0]
       return encoder.encode(notNullSchema, value)
    }
 }


### PR DESCRIPTION
## Summary
- `NullEncoder` and `NullDecoder` were doing `schema.types.first { !it.isNullable }` to pick the non-null branch of a 2-element union. Every nullable field hits this on every record, so the per-call lambda + iterator allocation is worth eliminating.
- Replaced with direct indexed access (`if (types[0].type == NULL) types[1] else types[0]`). Same semantics for well-formed 2-element unions.
- The null short-circuit (`if (value == null) return null`) is now hoisted above the branch picker so we don't compute the non-null schema for null values at all.
- `NullDecoder` still errors when neither branch is NULL — same as the previous `firstOrNull ?: error(...)` path.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)