### PR TITLE
perf: hoist schema.elementType in collection encoders/decoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -40,10 +40,11 @@ object PassthroughListDecoder : Decoder<List<Any?>> {
 
 class ListDecoder<T>(private val decoder: Decoder<T>) : Decoder<List<T>> {
    override fun decode(schema: Schema, value: Any?): List<T> {
+      val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is Collection<*> -> value.map { decoder.decode(schema.elementType, it) }
-         is Array<*> -> value.map { decoder.decode(schema.elementType, it) }
+         is Collection<*> -> value.map { decoder.decode(elementType, it) }
+         is Array<*> -> value.map { decoder.decode(elementType, it) }
          else -> error("Unsupported list type $value")
       }
    }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
@@ -8,8 +8,9 @@ import org.apache.avro.Schema
 class ArrayEncoder<T>(private val encoder: Encoder<T>) : Encoder<Array<T>> {
    override fun encode(schema: Schema, value: Array<T>): List<Any?> {
       require(schema.type == Schema.Type.ARRAY)
-      return if (value.isEmpty()) emptyList()
-      else value.map { encoder.encode(schema.elementType, it) }
+      if (value.isEmpty()) return emptyList()
+      val elementType = schema.elementType
+      return value.map { encoder.encode(elementType, it) }
    }
 }
 
@@ -39,8 +40,9 @@ class IntArrayEncoder : Encoder<IntArray> {
 class ListEncoder<T>(private val encoder: Encoder<T>) : Encoder<List<T>> {
    override fun encode(schema: Schema, value: List<T>): List<Any?> {
       require(schema.type == Schema.Type.ARRAY)
-      return if (value.isEmpty()) value
-      else value.map { encoder.encode(schema.elementType, it) }
+      if (value.isEmpty()) return value
+      val elementType = schema.elementType
+      return value.map { encoder.encode(elementType, it) }
    }
 }
 
@@ -65,8 +67,9 @@ object PassThroughListEncoder : Encoder<List<Any?>> {
 class SetEncoder<T>(private val encoder: Encoder<T>) : Encoder<Set<T>> {
    override fun encode(schema: Schema, value: Set<T>): List<Any?> {
       require(schema.type == Schema.Type.ARRAY)
-      return if (value.isEmpty()) emptyList()
-      else value.map { encoder.encode(schema.elementType, it) }
+      if (value.isEmpty()) return emptyList()
+      val elementType = schema.elementType
+      return value.map { encoder.encode(elementType, it) }
    }
 }
 


### PR DESCRIPTION
## Summary
- `ArrayEncoder`, `ListEncoder`, `SetEncoder`, and `ListDecoder` were each calling `schema.elementType` inside the per-element `map { }` lambda — so the getter ran once per element.
- Cached the element schema in a local before the loop. Identical semantics.
- Also flipped the empty-input branch from `return if (empty) X else value.map { ... }` to an early `return`, so the `elementType` lookup is skipped entirely on empty collections.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)