### PR TITLE
perf: MapEncoder pre-sized LinkedHashMap, no destructuring

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/collections.kt
@@ -83,6 +83,11 @@ class MapEncoder<T>(
    override fun encode(schema: Schema, value: Map<String, T>): Map<String, Any?> {
       require(schema.type == Schema.Type.MAP)
       if (value.isEmpty()) return emptyMap()
-      return value.mapValues { (_, v) -> valueEncoder.encode(schema.valueType, v) }
+      val valueType = schema.valueType
+      val result = LinkedHashMap<String, Any?>(value.size)
+      for (entry in value) {
+         result[entry.key] = valueEncoder.encode(valueType, entry.value)
+      }
+      return result
    }
 }


### PR DESCRIPTION
## Summary
- Replace `value.mapValues { (_, v) -> valueEncoder.encode(schema.valueType, v) }` with a hand-rolled loop into a pre-sized `LinkedHashMap`.
- Cache `schema.valueType` in a local before the loop (was being called once per entry).
- Iterate `value` directly so we don't destructure each `Map.Entry`.

For large maps this avoids resizes during insertion and drops the per-entry getter cost.

## Test plan
- [x] `./gradlew :centurion-avro:test` (MapEncoder + RoundTrip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)