### PR TITLE
perf: UTF8Decoder fast-path for Utf8 input

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
@@ -51,6 +51,7 @@ val CharSequenceDecoder: Decoder<CharSequence> = StringDecoder.map { it }
 object UTF8Decoder : Decoder<Utf8> {
    override fun decode(schema: Schema, value: Any?): Utf8 {
       return when (value) {
+         is Utf8 -> value
          is CharSequence -> Utf8(value.toString())
          is ByteArray -> Utf8(value)
          is ByteBuffer -> Utf8(value.readRemainingBytes())


### PR DESCRIPTION
## Summary
- Avro's `GenericDatumReader` typically hands strings to decoders as `Utf8`. The previous matcher hit the broader `CharSequence` branch first, which built `Utf8(value.toString())` — materialising the `String` and allocating a fresh `Utf8`.
- Added `is Utf8 -> value` as the first branch so the common case returns the input unchanged with zero allocation.

This is the exact pattern already used by `StringDecoder` for `is CharSequence -> value.toString()` (no-op for `String` inputs); the analogue was just missing here.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)