### PR TITLE
perf: EnumEncoder drop redundant Enum<*> cast

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/enums.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/enums.kt
@@ -10,7 +10,6 @@ import org.apache.avro.generic.GenericEnumSymbol
 class EnumEncoder<T : Enum<*>> : Encoder<T> {
    override fun encode(schema: Schema, value: T): GenericEnumSymbol<*> {
       require(schema.type == Schema.Type.ENUM)
-      val symbol = value as Enum<*>
-      return GenericData.EnumSymbol(schema, symbol.name)
+      return GenericData.EnumSymbol(schema, value.name)
    }
 }


### PR DESCRIPTION
## Summary
- `val symbol = value as Enum<*>` was redundant — the class is already declared `EnumEncoder<T : Enum<*>>`, so `value.name` is directly available.
- Inlined the `value.name` call into the `GenericData.EnumSymbol(...)` construction.

Small cleanup; removes a checkcast bytecode op that the JIT was probably eliding anyway, but it didn't belong there.

## Test plan
- [x] `./gradlew :centurion-avro:test` (EnumEncoder + RoundTrip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)