### PR TITLE
perf: BinarySerde.deserialize reads byte[] directly

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
@@ -4,13 +4,13 @@ import com.sksamuel.centurion.avro.decoders.Decoder
 import com.sksamuel.centurion.avro.decoders.ReflectionRecordDecoder
 import com.sksamuel.centurion.avro.encoders.Encoder
 import com.sksamuel.centurion.avro.encoders.ReflectionRecordEncoder
-import com.sksamuel.centurion.avro.io.BinaryReader
 import com.sksamuel.centurion.avro.io.BinaryWriter
 import com.sksamuel.centurion.avro.schemas.ReflectionSchemaBuilder
 import org.apache.avro.Schema
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import kotlin.reflect.KClass
 
@@ -67,6 +67,9 @@ class BinarySerde<T : Any>(
    }
 
    override fun deserialize(bytes: ByteArray): T {
-      return BinaryReader(schema, ByteArrayInputStream(bytes), decoderFactory, decoder, null).use { it.read() }
+      val binaryDecoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, null)
+      val datum = GenericDatumReader<GenericRecord>(schema, schema)
+      val record = datum.read(null, binaryDecoder)
+      return decoder.decode(schema, record)
    }
 }


### PR DESCRIPTION
## Summary
- The previous shape wrapped the input in a `ByteArrayInputStream` and went through `BinaryReader`, which itself wrapped that stream in a `BinaryDecoder`.
- Avro exposes `DecoderFactory.binaryDecoder(byte[], offset, length, reuse)` which reads from the array directly.
- New code drops both the `ByteArrayInputStream` and the `BinaryReader` wrapper — two fewer allocations per deserialize.

Same semantics: `BinaryDecoder` reads identical bytes either way. `BinaryReader` itself is untouched; it remains the right tool for streaming `InputStream`-based reads.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite, including RoundTrip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)