### PR TITLE
perf: BinaryReader reuses GenericRecord across reads

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/BinaryReader.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/BinaryReader.kt
@@ -30,9 +30,11 @@ class BinaryReader<T>(
 
    private val datum = GenericDatumReader<GenericRecord>(/* writer = */ writerSchema, /* reader = */ readerSchema)
    private val binaryDecoder = factory.binaryDecoder(input, reuse)
+   private var reusableRecord: GenericRecord? = null
 
    fun read(): T {
-      val record = datum.read(null, binaryDecoder)
+      val record = datum.read(reusableRecord, binaryDecoder)
+      reusableRecord = record
       return decoder.decode(readerSchema, record)
    }
 


### PR DESCRIPTION
## Summary
- `GenericDatumReader.read(reuse, decoder)` refills the fields of an existing record if one is passed. `BinaryReader` was always passing `null`, so every `read()` call allocated a brand-new `GenericRecord` even though the previous one was thrown away immediately after the decoder consumed it.
- Holds the previous record in a private `var reusableRecord` and feeds it back in on the next call.

Safe because `BinaryReader` is already documented as non-thread-safe (it owns a stateful `BinaryDecoder`). The behaviour change is invisible to callers — the record is converted to `T` before each `read()` returns, so the caller never observes the underlying scratch record.

## Test plan
- [x] `./gradlew :centurion-avro:test` (full suite, including RoundTrip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)