### PR TITLE
perf: ReflectionRecordDecoder indexed array loop

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/ReflectionRecordDecoder.kt
@@ -56,30 +56,31 @@ class ReflectionRecordDecoder<T : Any>(
       }
    }
 
-   private val decodeFn: ((GenericRecord) -> T) = buildDecodeFn(schema)
+   private val decoders: Array<Decoding> = buildDecodings(schema)
 
    override fun decode(schema: Schema, value: Any?): T {
       val record = value as GenericRecord
-      return decodeFn(record)
+      val decoders = this.decoders
+      val args = arrayOfNulls<Any?>(decoders.size)
+      var i = 0
+      while (i < decoders.size) {
+         val decoding = decoders[i]
+         args[i] = decoding.decoder.decode(decoding.schema, record.get(decoding.pos))
+         i++
+      }
+      return constructor.call(*args)
    }
 
-   private fun buildDecodeFn(schema: Schema): (GenericRecord) -> T {
-
-      val decoders = constructor.parameters.map { param ->
+   private fun buildDecodings(schema: Schema): Array<Decoding> {
+      val params = constructor.parameters
+      return Array(params.size) { i ->
+         val param = params[i]
          val avroField = schema.getField(param.name)
             ?: error("Could not find field ${param.name} in Avro schema")
          val decoder = Decoder.decoderFor(param.type, avroField.schema())
          Decoding(avroField.pos(), decoder, avroField.schema())
       }
-
-      return { record ->
-         val args = Array(decoders.size) { i ->
-            val (pos, decoder, fieldSchema) = decoders[i]
-            decoder.decode(fieldSchema, record.get(pos))
-         }
-         constructor.call(*args)
-      }
    }
 
-   private data class Decoding(val pos: Int, val decode: Decoder<*>, val schema: Schema)
+   private class Decoding(val pos: Int, val decoder: Decoder<*>, val schema: Schema)
 }


### PR DESCRIPTION
## Summary
Mirrors the optimization that already landed for `ReflectionRecordEncoder` (#79) on the decoder side:

- `decoders` is now an `Array<Decoding>` instead of `List<Decoding>`, so the per-record loop avoids `List.size` / `List.get` interface dispatch.
- `Decoding` is no longer a `data class`. The previous hot loop destructured `(pos, decoder, schema) = decoders[i]` for every field of every record, paying three `componentN` method calls + the destructuring synthetic.
- The `decodeFn: (GenericRecord) -> T` lambda is inlined into `decode()`. Removes one `Function1.invoke` dispatch per record.
- Constructor args are now built with `arrayOfNulls(size)` + index-assign in a `while` loop, instead of `Array(size) { i -> ... }`. The latter compiles to a `Function1` instantiation/invocation per record.
- Renamed the `Decoding.decode` property to `Decoding.decoder` so the field name no longer reads like a method.

Net effect: per-record fixed overhead reduced for any caller using `ReflectionRecordDecoder`, which is the default decoder for data-class records.

## Test plan
- [x] `./gradlew :centurion-avro:test` passes
- [ ] Compare `DeserializeBenchmark` numbers via the JMH workflow before/after