### PR TITLE
perf: Fixed encoders construct GenericData.Fixed directly

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bytes.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bytes.kt
@@ -19,15 +19,15 @@ object ByteBufferEncoder : Encoder<ByteBuffer> {
 }
 
 object FixedByteBufferEncoder : Encoder<ByteBuffer> {
-   private val instance = GenericData.get()
    override fun encode(schema: Schema, value: ByteBuffer): Any? {
       require(schema.type == Schema.Type.FIXED)
       val remaining = value.remaining()
-      if (remaining > schema.fixedSize)
-         error("Cannot write ByteBuffer with $remaining bytes to fixed type of size ${schema.fixedSize}")
-      val array = ByteArray(schema.fixedSize)
+      val fixedSize = schema.fixedSize
+      if (remaining > fixedSize)
+         error("Cannot write ByteBuffer with $remaining bytes to fixed type of size $fixedSize")
+      val array = ByteArray(fixedSize)
       value.duplicate().get(array, 0, remaining)
-      return instance.createFixed(null, array, schema)
+      return GenericData.Fixed(schema, array)
    }
 }
 
@@ -42,13 +42,13 @@ object ByteArrayEncoder : Encoder<ByteArray> {
 }
 
 object FixedByteArrayEncoder : Encoder<ByteArray> {
-   private val instance = GenericData.get()
    override fun encode(schema: Schema, value: ByteArray): Any? {
       require(schema.type == Schema.Type.FIXED)
-      if (value.size > schema.fixedSize)
-         error("Cannot write ByteArray with ${value.size} bytes to fixed type of size ${schema.fixedSize}")
-      val array = ByteArray(schema.fixedSize)
+      val fixedSize = schema.fixedSize
+      if (value.size > fixedSize)
+         error("Cannot write ByteArray with ${value.size} bytes to fixed type of size $fixedSize")
+      val array = ByteArray(fixedSize)
       System.arraycopy(value, 0, array, 0, value.size)
-      return instance.createFixed(null, array, schema)
+      return GenericData.Fixed(schema, array)
    }
 }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
@@ -63,14 +63,14 @@ object ByteStringEncoder : Encoder<String> {
  * An [Encoder] for Strings that encodes as [org.apache.avro.generic.GenericFixed]s.
  */
 object FixedStringEncoder : Encoder<String> {
-   private val instance = GenericData.get()
    override fun encode(schema: Schema, value: String): Any? {
       val bytes = value.encodeToByteArray()
-      if (bytes.size > schema.fixedSize)
-         error("Cannot write string with ${bytes.size} bytes to fixed type of size ${schema.fixedSize}")
-      val padded = if (bytes.size == schema.fixedSize) bytes else ByteArray(schema.fixedSize).also {
+      val fixedSize = schema.fixedSize
+      if (bytes.size > fixedSize)
+         error("Cannot write string with ${bytes.size} bytes to fixed type of size $fixedSize")
+      val padded = if (bytes.size == fixedSize) bytes else ByteArray(fixedSize).also {
          System.arraycopy(bytes, 0, it, 0, bytes.size)
       }
-      return instance.createFixed(null, padded, schema)
+      return GenericData.Fixed(schema, padded)
    }
 }


### PR DESCRIPTION
## Summary
The three `Fixed*Encoder`s (`FixedStringEncoder`, `FixedByteArrayEncoder`, `FixedByteBufferEncoder`) all wrap their already-padded byte array via `GenericData.get().createFixed(null, bytes, schema)`. That method:

1. Allocates a fresh `GenericData.Fixed(schema)` — whose no-byte-args constructor allocates a `byte[schema.fixedSize]` internally.
2. `System.arraycopy`s the caller-supplied bytes into that internal array.

Since each encoder already allocates a `ByteArray` of exactly `schema.fixedSize` and writes the data into it, we can hand that array directly to `GenericData.Fixed(Schema, byte[])` — eliminating both the second allocation and the arraycopy.

Net per-encode savings on FIXED fields: 1 `byte[fixedSize]` allocation + 1 `System.arraycopy`.

Also hoists `schema.fixedSize` into a local so the getter isn't read three times.

## Test plan
- [x] `./gradlew :centurion-avro:test`
- [ ] Confirm via JMH workflow if there's a benchmark covering FIXED fields