### PR TITLE
perf: replace map/contraMap wrappers with direct codec objects

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/strings.kt
@@ -40,7 +40,9 @@ object StringTypeDecoder : Decoder<String> {
  * The schema is not used, meaning this decoder is forgiving of types that do not conform to
  * the schema, but are nevertheless coerable to strings.
  */
-val CharSequenceDecoder: Decoder<CharSequence> = StringDecoder.map { it }
+object CharSequenceDecoder : Decoder<CharSequence> {
+   override fun decode(schema: Schema, value: Any?): CharSequence = StringDecoder.decode(schema, value)
+}
 
 /**
  * A [Decoder] for [Utf8] that pattern matches on the incoming type to decode.

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/temporal.kt
@@ -65,7 +65,10 @@ object LocalTimeDecoder : Decoder<LocalTime> {
    }
 }
 
-val OffsetDateTimeDecoder: Decoder<OffsetDateTime> = InstantDecoder.map { it.atOffset(ZoneOffset.UTC) }
+object OffsetDateTimeDecoder : Decoder<OffsetDateTime> {
+   override fun decode(schema: Schema, value: Any?): OffsetDateTime =
+      InstantDecoder.decode(schema, value).atOffset(ZoneOffset.UTC)
+}
 
 /**
  * [Decoder] for [LocalDateTime] which supports [LocalTimestampMillis], [LocalTimestampMicros] and Longs.

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigdecimal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigdecimal.kt
@@ -26,10 +26,9 @@ object BigDecimalBytesEncoder : Encoder<BigDecimal> {
  * An [Encoder] for [BigDecimal] that encodes as Strings.
  */
 object BigDecimalStringEncoder : Encoder<BigDecimal> {
-   private val encoder = StringEncoder.contraMap<BigDecimal> { it.toString() }
    override fun encode(schema: Schema, value: BigDecimal): Any? {
       require(schema.type == Schema.Type.STRING)
-      return encoder.encode(schema, value)
+      return StringEncoder.encode(schema, value.toString())
    }
 }
 

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/temporals.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/temporals.kt
@@ -72,4 +72,7 @@ object InstantEncoder : Encoder<Instant> {
    }
 }
 
-val OffsetDateTimeEncoder: Encoder<OffsetDateTime> = InstantEncoder.contraMap { it.toInstant() }
+object OffsetDateTimeEncoder : Encoder<OffsetDateTime> {
+   override fun encode(schema: Schema, value: OffsetDateTime): Any? =
+      InstantEncoder.encode(schema, value.toInstant())
+}


### PR DESCRIPTION
## Summary
Four codec definitions used `Decoder.map` or `Encoder.contraMap` to adapt a base codec:

- `BigDecimalStringEncoder` — `StringEncoder.contraMap { it.toString() }`
- `OffsetDateTimeEncoder` — `InstantEncoder.contraMap { it.toInstant() }`
- `OffsetDateTimeDecoder` — `InstantDecoder.map { it.atOffset(UTC) }`
- `CharSequenceDecoder` — `StringDecoder.map { it }` (pure identity — two extra dispatches for a no-op)

Each `.map`/`.contraMap` wraps the call in a `SAM { schema, value -> fn(base.decode/encode(...)) }` lambda. On the hot path that costs one extra `Function1.invoke` (the adapter `fn`) plus one extra `Decoder/Encoder` SAM dispatch on top of the base codec.

Replaced each with a direct `object` declaration that invokes the base codec and the adapter call inline. Same observable behavior on round-trip.

## Test plan
- [x] `./gradlew :centurion-avro:test`