### PR TITLE
ci: fix jmh workflow and allow benchmarking arbitrary commits

### DIFF
--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -1,5 +1,7 @@
 name: jmh
 
+run-name: jmh @ ${{ inputs.commit || github.sha }}
+
 on:
   push:
     branches:
@@ -10,6 +12,10 @@ on:
       - '*.md'
   workflow_dispatch:
     inputs:
+      commit:
+        description: 'Commit SHA, branch, or tag to benchmark (defaults to HEAD of the selected branch)'
+        required: false
+        default: ''
       include:
         description: 'JMH benchmark regex filter (e.g. SerializeBenchmark)'
         required: false
@@ -23,6 +29,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit || github.sha }}
 
       - uses: actions/setup-java@v4
         with:
@@ -50,6 +58,7 @@ jobs:
           summary-always: true
           auto-push: false
           save-data-file: false
+          skip-fetch-gh-pages: true
 
       - name: Upload raw JMH results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
- Fix the failing JMH workflow — `benchmark-action/github-action-benchmark` was fetching a non-existent `gh-pages` branch on every run. Added `skip-fetch-gh-pages: true` (safe because `auto-push: false` and `save-data-file: false` already mean we don't use that branch).
- Add a `commit` `workflow_dispatch` input so a run can target an arbitrary SHA / branch / tag. Empty (the default) falls back to `github.sha`, so push runs and bare "Run workflow" clicks behave exactly as before — but you can now point a benchmark run at any commit.
- Set `run-name` so each run's title in the Actions list shows the resolved ref it benchmarked.

## Test plan
- [ ] Push to this branch — the `push` trigger should NOT fire (filters require master/main), but a manual `workflow_dispatch` on this branch with no `commit` input should run against this branch's HEAD and finish without the `gh-pages` error.
- [ ] Trigger `workflow_dispatch` with `commit` set to an older SHA — confirm checkout pins to that commit and the run-name reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)