### PR TITLE
perf: hoist union resolution out of NullDecoder/NullEncoder hot path

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -71,7 +71,7 @@ fun interface Decoder<T> {
             is KClass<*> if classifier.isData -> ReflectionRecordDecoder(schema, classifier)
             else -> error("No Decoder available for type $type with schema ${schema.type} ($schema)")
          }
-         return if (type.isMarkedNullable) NullDecoder(decoder) else decoder
+         return if (type.isMarkedNullable) NullDecoder(schema, decoder) else decoder
       }
    }
 }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/nullable.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/nullable.kt
@@ -1,16 +1,25 @@
 package com.sksamuel.centurion.avro.decoders
 
+import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
 
-class NullDecoder<T>(private val decoder: Decoder<T>) : Decoder<T?> {
+/**
+ * A [Decoder] that wraps another decoder and handles nullables.
+ *
+ * The non-null component of the union is resolved once at construction time so
+ * that per-decode work is reduced to a null check plus delegation.
+ */
+class NullDecoder<T>(unionSchema: Schema, private val decoder: Decoder<T>) : Decoder<T?> {
+
+   private val nonNullSchema: Schema
+
+   init {
+      require(unionSchema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
+      require(unionSchema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
+      nonNullSchema = unionSchema.unionNonNullComponent()
+   }
+
    override fun decode(schema: Schema, value: Any?): T? {
-      // nullables must be encoded with a union of 2 elements, where null is the first type
-      require(schema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
-      require(schema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
-      val nullableType = schema.types.firstOrNull { !it.isNullable }
-         ?: error("One of the elements of a nullable union must not be null")
-      return if (value == null) null else {
-         decoder.decode(nullableType, value)
-      }
+      return if (value == null) null else decoder.decode(nonNullSchema, value)
    }
 }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -99,7 +99,7 @@ fun interface Encoder<T> {
             is KClass<*> if classifier.isData -> ReflectionRecordEncoder(schema, classifier)
             else -> error("No Encoder available for type $type with schema ${schema.type} ($schema)")
          }
-         return if (type.isMarkedNullable) NullEncoder(encoder) else encoder
+         return if (type.isMarkedNullable) NullEncoder(schema, encoder) else encoder
       }
    }
 

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/nulls.kt
@@ -1,17 +1,25 @@
 package com.sksamuel.centurion.avro.encoders
 
+import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
 
 /**
  * An [Encoder] that wraps another encoder and handles nullables.
+ *
+ * The non-null component of the union is resolved once at construction time so
+ * that per-encode work is reduced to a null check plus delegation.
  */
-class NullEncoder<T>(private val encoder: Encoder<T>) : Encoder<T?> {
+class NullEncoder<T>(unionSchema: Schema, private val encoder: Encoder<T>) : Encoder<T?> {
+
+   private val nonNullSchema: Schema
+
+   init {
+      require(unionSchema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
+      require(unionSchema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
+      nonNullSchema = unionSchema.unionNonNullComponent()
+   }
+
    override fun encode(schema: Schema, value: T?): Any? {
-      // nullables must be encoded with a union of 2 elements
-      require(schema.type == Schema.Type.UNION) { "Nulls can only be encoded with a UNION schema" }
-      require(schema.types.size == 2) { "Nulls can only be encoded with a 2 element union schema" }
-      if (value == null) return null
-      val notNullSchema = schema.types.first { !it.isNullable }
-      return encoder.encode(notNullSchema, value)
+      return if (value == null) null else encoder.encode(nonNullSchema, value)
    }
 }

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/generation/RecordDecoderGenerator.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/generation/RecordDecoderGenerator.kt
@@ -48,7 +48,8 @@ class RecordDecoderGenerator {
 
    private fun decode(property: KProperty1<out Any, *>): String {
       val baseDecoder = decoderFor(property.returnType)
-      val wrapped = if (property.returnType.isMarkedNullable) "NullDecoder($baseDecoder)" else baseDecoder
+      val wrapped = if (property.returnType.isMarkedNullable)
+         "NullDecoder(${property.name}Schema, $baseDecoder)" else baseDecoder
       return "$wrapped.decode(${property.name}Schema)"
    }
 

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/generation/RecordEncoderGenerator.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/generation/RecordEncoderGenerator.kt
@@ -49,7 +49,8 @@ class RecordEncoderGenerator {
 
    private fun encode(property: KProperty1<out Any, *>): String {
       val baseEncoder = encoderFor(property.returnType)
-      val wrapped = if (property.returnType.isMarkedNullable) "NullEncoder($baseEncoder)" else baseEncoder
+      val wrapped = if (property.returnType.isMarkedNullable)
+         "NullEncoder(${property.name}Schema, $baseEncoder)" else baseEncoder
       return "$wrapped.encode(${property.name}Schema)"
    }
 

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/NullDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/NullDecoderTest.kt
@@ -8,8 +8,8 @@ class NullDecoderTest : FunSpec({
 
    test("decode null") {
       val schema = SchemaBuilder.nullable().intType()
-      NullDecoder(IntDecoder).decode(schema, null) shouldBe null
-      NullDecoder(IntDecoder).decode(schema, 1) shouldBe 1
+      NullDecoder(schema, IntDecoder).decode(schema, null) shouldBe null
+      NullDecoder(schema, IntDecoder).decode(schema, 1) shouldBe 1
    }
 
 })

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/NullEncoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/NullEncoderTest.kt
@@ -12,28 +12,28 @@ class NullEncoderTest : FunSpec({
    val nullableString = Schema.create(Schema.Type.STRING).asNullUnion()
 
    test("encodes null as null") {
-      NullEncoder(StringEncoder).encode(nullableString, null) shouldBe null
+      NullEncoder(nullableString, StringEncoder).encode(nullableString, null) shouldBe null
    }
 
    test("delegates non-null values to the wrapped encoder") {
-      NullEncoder(StringEncoder).encode(nullableString, "hello") shouldBe Utf8("hello")
+      NullEncoder(nullableString, StringEncoder).encode(nullableString, "hello") shouldBe Utf8("hello")
    }
 
-   test("requires a UNION schema") {
+   test("requires a UNION schema at construction") {
       val schema = Schema.create(Schema.Type.STRING)
       shouldThrow<IllegalArgumentException> {
-         NullEncoder(StringEncoder).encode(schema, "x")
+         NullEncoder(schema, StringEncoder)
       }
    }
 
-   test("requires a 2-element union") {
+   test("requires a 2-element union at construction") {
       val schema = Schema.createUnion(
          Schema.create(Schema.Type.NULL),
          Schema.create(Schema.Type.STRING),
          Schema.create(Schema.Type.INT),
       )
       shouldThrow<IllegalArgumentException> {
-         NullEncoder(StringEncoder).encode(schema, "x")
+         NullEncoder(schema, StringEncoder)
       }
    }
 })


### PR DESCRIPTION
## Summary
- `NullDecoder` / `NullEncoder` used to re-validate the union schema and walk `schema.types` to find the non-null component on every encode/decode call.
- Move validation + lookup to construction time. Per-call work is now `if (value == null) null else delegate.decode/encode(nonNullSchema, value)`.
- Constructor now takes the union `Schema` as its first arg. `Decoder.decoderFor` / `Encoder.encoderFor` (the two real callers) already have the schema and pass it through.
- Updated the two existing tests (`NullDecoderTest`, `NullEncoderTest`) and the (currently dead/commented-out) record generators so they emit the new signature.

## Test plan
- [x] `./gradlew :centurion-avro:test` passes locally
- [ ] JMH `SerializeBenchmark` / `DeserializeBenchmark` show a measurable improvement on records with nullable fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)