### PR TITLE
perf: short-circuit setScale in BigDecimal encoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigdecimal.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigdecimal.kt
@@ -4,6 +4,7 @@ import org.apache.avro.Conversions
 import org.apache.avro.LogicalTypes
 import org.apache.avro.Schema
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * An [Encoder] for [BigDecimal] that encodes as byte arrays.
@@ -14,11 +15,10 @@ object BigDecimalBytesEncoder : Encoder<BigDecimal> {
 
    override fun encode(schema: Schema, value: BigDecimal): Any? {
       require(schema.type == Schema.Type.BYTES)
-
       val logical = schema.logicalType as LogicalTypes.Decimal
-      val rm = java.math.RoundingMode.HALF_UP
-
-      return converter.toBytes(value.setScale(logical.scale, rm), schema, logical)
+      val scaled = if (value.scale() == logical.scale) value
+      else value.setScale(logical.scale, RoundingMode.HALF_UP)
+      return converter.toBytes(scaled, schema, logical)
    }
 }
 
@@ -41,10 +41,9 @@ object BigDecimalFixedEncoder : Encoder<BigDecimal> {
 
    override fun encode(schema: Schema, value: BigDecimal): Any? {
       require(schema.type == Schema.Type.FIXED)
-
       val logical = schema.logicalType as LogicalTypes.Decimal
-      val rm = java.math.RoundingMode.HALF_UP
-
-      return converter.toFixed(value.setScale(logical.scale, rm), schema, logical)
+      val scaled = if (value.scale() == logical.scale) value
+      else value.setScale(logical.scale, RoundingMode.HALF_UP)
+      return converter.toFixed(scaled, schema, logical)
    }
 }


### PR DESCRIPTION
## Summary
- `BigDecimalBytesEncoder` and `BigDecimalFixedEncoder` unconditionally called `value.setScale(logical.scale, HALF_UP)`, which allocates a fresh `BigDecimal` every encode.
- When the input already has the target scale (the common case for app data shaped to its schema), that allocation is wasted.
- Skip the rescale + allocation when `value.scale() == logical.scale`.
- Hoist `java.math.RoundingMode` to a normal import while here.

## Test plan
- [x] `./gradlew :centurion-avro:test` passes — `BigDecimalEncoderTest` still green
- [ ] JMH on a workload with `BigDecimal` fields would show the win

🤖 Generated with [Claude Code](https://claude.com/claude-code)