### PR TITLE
perf: reuse BinarySerde state across calls

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
@@ -4,11 +4,13 @@ import com.sksamuel.centurion.avro.decoders.Decoder
 import com.sksamuel.centurion.avro.decoders.ReflectionRecordDecoder
 import com.sksamuel.centurion.avro.encoders.Encoder
 import com.sksamuel.centurion.avro.encoders.ReflectionRecordEncoder
-import com.sksamuel.centurion.avro.io.BinaryWriter
 import com.sksamuel.centurion.avro.schemas.ReflectionSchemaBuilder
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
+import org.apache.avro.io.BinaryDecoder
+import org.apache.avro.io.BinaryEncoder
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
 import java.io.ByteArrayOutputStream
@@ -22,6 +24,10 @@ import kotlin.reflect.KClass
  * deserialization time. This format is especially effective when the consumers and producers both know the
  * schema that was used, for instance, in versioned endpoints, or when the same application is used to read
  * and write the data.
+ *
+ * Instances are safe to share across threads. Per-thread mutable state
+ * ([ByteArrayOutputStream], [BinaryEncoder], [BinaryDecoder]) is held in [ThreadLocal]s and reused
+ * across calls; the schema-bound [GenericDatumWriter] / [GenericDatumReader] are shared.
  */
 class BinarySerde<T : Any>(
    private val schema: Schema,
@@ -60,16 +66,28 @@ class BinarySerde<T : Any>(
       }
    }
 
+   private val datumWriter = GenericDatumWriter<GenericRecord>(schema)
+   private val datumReader = GenericDatumReader<GenericRecord>(schema, schema)
+
+   private val baosLocal = ThreadLocal.withInitial { ByteArrayOutputStream(256) }
+   private val binaryEncoderLocal = ThreadLocal<BinaryEncoder?>()
+   private val binaryDecoderLocal = ThreadLocal<BinaryDecoder?>()
+
    override fun serialize(obj: T): ByteArray {
-      val baos = ByteArrayOutputStream()
-      BinaryWriter(schema, baos, encoderFactory, encoder, null).use { it.write(obj) }
+      val baos = baosLocal.get()
+      baos.reset()
+      val binEncoder = encoderFactory.binaryEncoder(baos, binaryEncoderLocal.get())
+      binaryEncoderLocal.set(binEncoder)
+      val record = encoder.encode(schema, obj) as GenericRecord
+      datumWriter.write(record, binEncoder)
+      binEncoder.flush()
       return baos.toByteArray()
    }
 
    override fun deserialize(bytes: ByteArray): T {
-      val binaryDecoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, null)
-      val datum = GenericDatumReader<GenericRecord>(schema, schema)
-      val record = datum.read(null, binaryDecoder)
+      val binDecoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, binaryDecoderLocal.get())
+      binaryDecoderLocal.set(binDecoder)
+      val record = datumReader.read(null, binDecoder)
       return decoder.decode(schema, record)
    }
 }


### PR DESCRIPTION
## Summary

`BinarySerde.serialize` and `.deserialize` allocated per-call:
- A fresh `ByteArrayOutputStream` (serialize)
- A fresh `BinaryWriter` wrapper, plus the `GenericDatumWriter` and `BinaryEncoder` it builds inside its constructor (serialize)
- A fresh `GenericDatumReader` (deserialize)
- A fresh `BinaryDecoder` (deserialize)

Two changes:

1. **Hoist the schema-bound state to fields.** `GenericDatumWriter` / `GenericDatumReader` are effectively immutable after construction for a given schema, so they can be shared across threads. One instance per `BinarySerde`.
2. **Reuse the mutable per-call helpers via `ThreadLocal`.** `ByteArrayOutputStream` is `reset()` between calls (preserves the internal buffer's capacity), and `BinaryEncoder` / `BinaryDecoder` are passed back to the Avro factory as the `reuse` argument. The class stays implicitly thread-safe — each thread sees its own buffer + encoder/decoder.

The serialize path now skips the `BinaryWriter` wrapper entirely and writes directly through the cached datum writer, mirroring the pattern that `SerializeBenchmark.serializeAvroProgramaticallyWithReuse` already establishes as the fast path.

`BinaryWriter` / `BinaryReader` (the public per-stream wrappers used by power users with their own buffering) are unchanged.

## Test plan
- [x] `./gradlew :centurion-avro:test` — full suite green, including `BinarySerdeTest` round-trip.
- [ ] `SerializeBenchmark` / `DeserializeBenchmark` — expected improvement on per-call paths since the convenience API now matches the programmatic fast path internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)