### PR TITLE
perf: reuse DataSerde state across calls + fix null-codec NPE

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/DataSerde.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/DataSerde.kt
@@ -4,11 +4,15 @@ import com.sksamuel.centurion.avro.decoders.Decoder
 import com.sksamuel.centurion.avro.decoders.ReflectionRecordDecoder
 import com.sksamuel.centurion.avro.encoders.Encoder
 import com.sksamuel.centurion.avro.encoders.ReflectionRecordEncoder
-import com.sksamuel.centurion.avro.io.DataReader
-import com.sksamuel.centurion.avro.io.DataWriter
 import com.sksamuel.centurion.avro.schemas.ReflectionSchemaBuilder
 import org.apache.avro.Schema
 import org.apache.avro.file.CodecFactory
+import org.apache.avro.file.DataFileReader
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.file.SeekableByteArrayInput
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.generic.GenericDatumWriter
+import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
 import java.io.ByteArrayOutputStream
@@ -20,6 +24,11 @@ import kotlin.reflect.KClass
  * This format results in larger sizes than [BinarySerde], as clearly including the schema requires
  * more bytes, but supports schema evolution, as the deserializers can compare the expected schema
  * with the written schema.
+ *
+ * Instances are safe to share across threads. The per-thread [ByteArrayOutputStream] is held in a
+ * [ThreadLocal] and reset between calls; the schema-bound [GenericDatumWriter] / [GenericDatumReader]
+ * are shared. The Avro [DataFileWriter] / [DataFileReader] still bind to a specific stream, so they
+ * are created per call.
  */
 class DataSerde<T : Any>(
    private val schema: Schema,
@@ -59,13 +68,25 @@ class DataSerde<T : Any>(
       }
    }
 
+   private val datumWriter = GenericDatumWriter<GenericRecord>(schema)
+   private val datumReader = GenericDatumReader<GenericRecord>(schema, schema)
+
+   private val baosLocal = ThreadLocal.withInitial { ByteArrayOutputStream(256) }
+
    override fun serialize(obj: T): ByteArray {
-      val baos = ByteArrayOutputStream()
-      DataWriter(schema, baos, encoder, codecFactory).use { it.write(obj) }
+      val baos = baosLocal.get()
+      baos.reset()
+      val record = encoder.encode(schema, obj) as GenericRecord
+      val writer = DataFileWriter(datumWriter)
+      if (codecFactory != null) writer.setCodec(codecFactory)
+      writer.create(schema, baos).use { it.append(record) }
       return baos.toByteArray()
    }
 
    override fun deserialize(bytes: ByteArray): T {
-      return DataReader(bytes, schema, decoder).use { it.next() }
+      val input = SeekableByteArrayInput(bytes)
+      return DataFileReader.openReader(input, datumReader).use { reader ->
+         decoder.decode(schema, reader.next())
+      }
    }
 }

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/io/DataSerdeTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/io/DataSerdeTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.centurion.avro.io
+
+import com.sksamuel.centurion.avro.io.serde.DataSerde
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.file.CodecFactory
+import org.apache.avro.io.DecoderFactory
+import org.apache.avro.io.EncoderFactory
+
+class DataSerdeTest : FunSpec({
+
+   val profile = MyObj(
+      long = 123,
+      nullableLong = 0,
+      nullableString = null,
+      age = 432,
+      double = null,
+      bool = true,
+      strings = setOf("foo", "bar"),
+      ints = setOf(1, 2),
+      nullableMap = null,
+   )
+
+   test("round trip happy path with no codec") {
+      val serde = DataSerde<MyObj>(EncoderFactory.get(), DecoderFactory.get(), null)
+      serde.deserialize(serde.serialize(profile)) shouldBe profile
+   }
+
+   test("round trip happy path with deflate codec") {
+      val serde = DataSerde<MyObj>(EncoderFactory.get(), DecoderFactory.get(), CodecFactory.deflateCodec(6))
+      serde.deserialize(serde.serialize(profile)) shouldBe profile
+   }
+
+   test("reuses ThreadLocal buffer across calls") {
+      val serde = DataSerde<MyObj>(EncoderFactory.get(), DecoderFactory.get(), null)
+      repeat(5) {
+         serde.deserialize(serde.serialize(profile)) shouldBe profile
+      }
+   }
+})


### PR DESCRIPTION
## Summary

Mirrors the `BinarySerde` refactor from #94, applied to `DataSerde`:

- Hoist the schema-bound `GenericDatumWriter` / `GenericDatumReader` to fields and share across threads.
- `ThreadLocal` the per-call `ByteArrayOutputStream` and `reset()` it between calls so we don't reallocate the buffer.
- Inline `serialize` / `deserialize` so they no longer go through the `DataWriter` / `DataReader` convenience wrappers (those build the `DatumWriter` / `DatumReader` in their own constructors, which would defeat the caching).

`DataFileWriter` and `DataFileReader` still bind to a specific stream, so they're constructed per call — the unavoidable cost of the container file format (header + footer per `serialize` call). The big remaining cost for `DataSerde` is the schema-in-payload format itself, not the codec setup.

## Bug fix included

Found a latent NPE while writing the missing test: `DataFileWriter.setCodec(null)` throws on this Avro version (`Cannot invoke "CodecFactory.createInstance()" because "c" is null`). The original `DataWriter` called `.setCodec(codecFactory)` unconditionally, so any `DataSerde` instance constructed via the no-codec default constructor on `DataSerdeFactory()` would NPE on the first `serialize`. The refactor now only calls `setCodec` when a non-null codec is provided.

Adds `DataSerdeTest` (previously missing) covering: no-codec round trip, deflate-codec round trip, repeated calls (to exercise the `ThreadLocal` buffer reset path).

## Test plan
- [x] `./gradlew :centurion-avro:test` — full suite green, including new `DataSerdeTest`.
- [ ] Would benefit from a JMH benchmark mirroring `SerializeBenchmark` but using the `DataFile*` path — none exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)