### PR TITLE
feat: add centurion-spring-grpc module

### DIFF
--- a/centurion-spring-grpc/build.gradle.kts
+++ b/centurion-spring-grpc/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+   id("kotlin-conventions")
+   id("publishing-conventions")
+}
+
+dependencies {
+   api(projects.centurionAvro)
+   api(libs.avro)
+   api(libs.spring.grpc.server.starter)
+}

--- a/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroMarshaller.kt
+++ b/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroMarshaller.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.centurion.spring.grpc
+
+import com.sksamuel.centurion.avro.io.serde.BinarySerde
+import com.sksamuel.centurion.avro.io.serde.Serde
+import io.grpc.MethodDescriptor
+import org.apache.avro.io.DecoderFactory
+import org.apache.avro.io.EncoderFactory
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import kotlin.reflect.KClass
+
+/**
+ * A gRPC [MethodDescriptor.Marshaller] that serializes / deserializes values of type [T] using
+ * a centurion-avro [Serde].
+ *
+ * Use as the request or response marshaller of a [MethodDescriptor]. By default this wraps a
+ * [BinarySerde], which produces the same payload shape as protobuf in terms of "schema is implicit,
+ * payload is just bytes". See [forBinary] and [forSerde] for factory methods.
+ *
+ * The underlying [Serde] is expected to be thread-safe; the marshaller itself adds no extra state.
+ */
+class AvroMarshaller<T : Any>(private val serde: Serde<T>) : MethodDescriptor.Marshaller<T> {
+
+   override fun stream(value: T): InputStream = ByteArrayInputStream(serde.serialize(value))
+
+   override fun parse(stream: InputStream): T = serde.deserialize(stream.readAllBytes())
+
+   companion object {
+
+      /**
+       * Builds an [AvroMarshaller] backed by a [BinarySerde] for [T] using reflection
+       * to generate the schema, encoder, and decoder.
+       */
+      inline fun <reified T : Any> forBinary(
+         encoderFactory: EncoderFactory = EncoderFactory.get(),
+         decoderFactory: DecoderFactory = DecoderFactory.get(),
+      ): AvroMarshaller<T> = forBinary(T::class, encoderFactory, decoderFactory)
+
+      /**
+       * Builds an [AvroMarshaller] backed by a [BinarySerde] for [kclass] using reflection
+       * to generate the schema, encoder, and decoder.
+       */
+      fun <T : Any> forBinary(
+         kclass: KClass<T>,
+         encoderFactory: EncoderFactory = EncoderFactory.get(),
+         decoderFactory: DecoderFactory = DecoderFactory.get(),
+      ): AvroMarshaller<T> = AvroMarshaller(BinarySerde(kclass, encoderFactory, decoderFactory))
+
+      /**
+       * Builds an [AvroMarshaller] backed by a caller-provided [Serde].
+       */
+      fun <T : Any> forSerde(serde: Serde<T>): AvroMarshaller<T> = AvroMarshaller(serde)
+   }
+}

--- a/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroMethodDescriptors.kt
+++ b/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroMethodDescriptors.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.centurion.spring.grpc
+
+import io.grpc.MethodDescriptor
+import kotlin.reflect.KClass
+
+/**
+ * Convenience factory methods for building [MethodDescriptor]s whose request and response
+ * marshallers are [AvroMarshaller]s backed by centurion-avro.
+ */
+object AvroMethodDescriptors {
+
+   /**
+    * Builds a [MethodDescriptor] for the given [fullMethodName] (e.g. "myservice.MyService/MyMethod")
+    * with Avro-backed request and response marshallers.
+    */
+   inline fun <reified Req : Any, reified Resp : Any> unary(
+      fullMethodName: String,
+   ): MethodDescriptor<Req, Resp> = unary(fullMethodName, Req::class, Resp::class)
+
+   /**
+    * Builds a unary [MethodDescriptor] with Avro-backed marshallers for the given request and
+    * response [KClass]es.
+    */
+   fun <Req : Any, Resp : Any> unary(
+      fullMethodName: String,
+      requestClass: KClass<Req>,
+      responseClass: KClass<Resp>,
+   ): MethodDescriptor<Req, Resp> = MethodDescriptor.newBuilder<Req, Resp>()
+      .setType(MethodDescriptor.MethodType.UNARY)
+      .setFullMethodName(fullMethodName)
+      .setRequestMarshaller(AvroMarshaller.forBinary(requestClass))
+      .setResponseMarshaller(AvroMarshaller.forBinary(responseClass))
+      .build()
+}

--- a/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroServerBuilderCustomizer.kt
+++ b/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/AvroServerBuilderCustomizer.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.centurion.spring.grpc
+
+import io.grpc.ServerBuilder
+import io.grpc.ServerServiceDefinition
+import org.springframework.grpc.server.ServerBuilderCustomizer
+
+/**
+ * A [ServerBuilderCustomizer] that adds a fixed list of [ServerServiceDefinition]s to the
+ * gRPC server. Typical use: build service definitions whose method descriptors use
+ * Avro-backed [AvroMarshaller]s (e.g. via [AvroMethodDescriptors]) and register them as Spring
+ * beans; this customizer picks them up and attaches them to the configured gRPC server.
+ *
+ * Generic over the concrete builder type to satisfy [ServerBuilderCustomizer]'s recursive bound;
+ * the [customize] body only calls [ServerBuilder.addService], which is defined on the base
+ * class, so any concrete builder works.
+ *
+ * If [definitions] is empty, this customizer is a no-op.
+ */
+class AvroServerBuilderCustomizer<T : ServerBuilder<T>>(
+   private val definitions: List<ServerServiceDefinition>,
+) : ServerBuilderCustomizer<T> {
+
+   override fun customize(serverBuilder: T) {
+      for (definition in definitions) {
+         serverBuilder.addService(definition)
+      }
+   }
+}

--- a/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/CenturionGrpcAutoConfiguration.kt
+++ b/centurion-spring-grpc/src/main/kotlin/com/sksamuel/centurion/spring/grpc/CenturionGrpcAutoConfiguration.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.centurion.spring.grpc
+
+import io.grpc.ServerServiceDefinition
+import io.grpc.netty.NettyServerBuilder
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.context.annotation.Bean
+import org.springframework.grpc.server.ServerBuilderCustomizer
+
+/**
+ * Spring Boot auto-configuration that exposes an [AvroServerBuilderCustomizer] bean collecting
+ * every [ServerServiceDefinition] in the application context.
+ *
+ * Users register their Avro-marshalled services as `ServerServiceDefinition` beans (built via
+ * [AvroMethodDescriptors] or by hand) and this auto-configuration wires them into the gRPC
+ * server. If no [ServerServiceDefinition] beans are defined, the customizer is a no-op.
+ *
+ * The bean is typed for [NettyServerBuilder], which Spring gRPC's server starter brings in
+ * transitively. Users running on a different server impl can define their own customizer for
+ * that builder type.
+ */
+@AutoConfiguration
+@ConditionalOnClass(ServerBuilderCustomizer::class, NettyServerBuilder::class)
+class CenturionGrpcAutoConfiguration {
+
+   @Bean
+   fun avroServerBuilderCustomizer(
+      definitions: List<ServerServiceDefinition>,
+   ): AvroServerBuilderCustomizer<NettyServerBuilder> = AvroServerBuilderCustomizer(definitions)
+}

--- a/centurion-spring-grpc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/centurion-spring-grpc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.sksamuel.centurion.spring.grpc.CenturionGrpcAutoConfiguration

--- a/centurion-spring-grpc/src/test/kotlin/com/sksamuel/centurion/spring/grpc/AvroMarshallerTest.kt
+++ b/centurion-spring-grpc/src/test/kotlin/com/sksamuel/centurion/spring/grpc/AvroMarshallerTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.centurion.spring.grpc
+
+import io.grpc.MethodDescriptor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+data class Person(val name: String, val age: Int, val nickname: String?)
+
+class AvroMarshallerTest : FunSpec({
+
+   test("round trip via stream / parse") {
+      val marshaller = AvroMarshaller.forBinary<Person>()
+      val original = Person("Ada", 36, "Augusta")
+      val parsed = marshaller.parse(marshaller.stream(original))
+      parsed shouldBe original
+   }
+
+   test("round trip with null field") {
+      val marshaller = AvroMarshaller.forBinary<Person>()
+      val original = Person("Ada", 36, null)
+      val parsed = marshaller.parse(marshaller.stream(original))
+      parsed shouldBe original
+   }
+
+   test("reuses underlying serde across calls") {
+      val marshaller = AvroMarshaller.forBinary<Person>()
+      val people = listOf(
+         Person("Ada", 36, "Augusta"),
+         Person("Grace", 85, null),
+         Person("Linus", 56, "Linus"),
+      )
+      people.forEach { p ->
+         marshaller.parse(marshaller.stream(p)) shouldBe p
+      }
+   }
+
+   test("AvroMethodDescriptors builds a unary descriptor with Avro marshallers") {
+      val descriptor: MethodDescriptor<Person, Person> =
+         AvroMethodDescriptors.unary("people.PeopleService/Echo")
+      descriptor.fullMethodName shouldBe "people.PeopleService/Echo"
+      descriptor.type shouldBe MethodDescriptor.MethodType.UNARY
+      val original = Person("Ada", 36, null)
+      descriptor.parseRequest(descriptor.streamRequest(original)) shouldBe original
+      descriptor.parseResponse(descriptor.streamResponse(original)) shouldBe original
+   }
+})

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 include("centurion-avro")
 include("centurion-avro-lettuce")
+include("centurion-spring-grpc")
 //include("centurion-avro-gradle-plugin")
 include("centurion-benchmarks")
 
@@ -42,6 +43,8 @@ dependencyResolutionManagement {
          library("jackson-module-kotlin", "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
 
          library("lettuce-core", "io.lettuce:lettuce-core:6.7.1.RELEASE")
+
+         library("spring-grpc-server-starter", "org.springframework.grpc:spring-grpc-server-spring-boot-starter:0.8.0")
 
          library("commons-pool", "org.apache.commons:commons-pool2:2.12.1")
 


### PR DESCRIPTION
## Summary

A new module that lets Spring gRPC services use Avro-backed marshalling via centurion-avro.

### What's in it

- **`AvroMarshaller<T>`** — a gRPC `MethodDescriptor.Marshaller<T>` backed by a centurion-avro `Serde<T>`. `stream(value)` serialises to a `ByteArrayInputStream`; `parse(in)` reads all bytes and deserialises. Convenience factory `AvroMarshaller.forBinary<T>()` builds one from a `BinarySerde<T>` via reflection.

- **`AvroMethodDescriptors`** — helpers for building `MethodDescriptor<Req, Resp>` whose request and response marshallers are Avro-backed. Currently just `unary(...)`; can be extended to server-streaming / client-streaming / bidi.

- **`AvroServerBuilderCustomizer<T : ServerBuilder<T>>`** — a Spring gRPC [`ServerBuilderCustomizer`](https://github.com/spring-projects/spring-grpc/blob/main/spring-grpc-core/src/main/java/org/springframework/grpc/server/ServerBuilderCustomizer.java) that registers a list of `ServerServiceDefinition`s on the gRPC `ServerBuilder`. Generic over the concrete builder type to satisfy the interface's recursive bound; the customize body only calls `addService`, which is on the base class, so any concrete builder works.

- **`CenturionGrpcAutoConfiguration`** — Spring Boot auto-config that exposes an `AvroServerBuilderCustomizer` bean collecting every `ServerServiceDefinition` in the context. Conditional on `ServerBuilderCustomizer` + `NettyServerBuilder` (the dominant server impl that the `spring-grpc-server` starter brings in transitively).

- `AutoConfiguration.imports` registers the auto-config with Spring Boot 3.x.

### Default serde choice
`BinarySerde` (no schema in payload). Smaller wire size and matches gRPC's usual fixed-contract model — both sides agree on the schema. Users wanting schema-in-payload can build their own marshaller via `AvroMarshaller.forSerde(DataSerde(...))`.

### Usage sketch
```kotlin
@Configuration
class MyServices {

   data class Greeting(val message: String)
   data class HelloRequest(val name: String)

   @Bean
   fun helloService(): ServerServiceDefinition {
      val method = AvroMethodDescriptors.unary<HelloRequest, Greeting>("greet.GreetService/Hello")
      return ServerServiceDefinition.builder("greet.GreetService")
         .addMethod(method) { request, responseObserver ->
            responseObserver.onNext(Greeting("Hello, ${request.name}"))
            responseObserver.onCompleted()
         }
         .build()
   }
}
```

The auto-config picks up `helloService` and registers it on the gRPC server.

## Test plan
- [x] `AvroMarshallerTest` — round trip via stream/parse, including a null field; multi-call reuse; round trip via a constructed `MethodDescriptor`.
- [x] `./gradlew :centurion-spring-grpc:test` and `./gradlew build` both green.
- [ ] Would benefit from an `@SpringBootTest` integration test that boots an in-process gRPC server with a real Avro-marshalled service — out of scope for this initial PR; can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)