### PR TITLE
docs: list every supported encoder/decoder type in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,32 +223,37 @@ Centurion provides built-in encoders and decoders for a comprehensive set of typ
 
 ### Avro Type Support
 
-| Type                           | Encoder/Decoder | Notes                                               |
-|--------------------------------|-----------------|-----------------------------------------------------|
-| **Primitives**                 |                 |                                                     |
-| `Byte`, `Short`, `Int`, `Long` | ✓               | Direct mapping to Avro types                        |
-| `Float`, `Double`              | ✓               | IEEE 754 floating point                             |
-| `Boolean`                      | ✓               |                                                     |
-| `String`                       | ✓               | UTF-8 encoded, optimized with `globalUseJavaString` |
-| **Temporal Types**             |                 |                                                     |
-| `Instant`                      | ✓               | TimestampMillis/TimestampMicros logical types       |
-| `LocalDateTime`                | ✓               | LocalTimestampMillis/LocalTimestampMicros           |
-| `LocalTime`                    | ✓               | TimeMillis/TimeMicros logical types                 |
-| `OffsetDateTime`               | ✓               | Converted to Instant                                |
-| **Numeric Types**              |                 |                                                     |
-| `BigDecimal`                   | ✓               | Bytes/Fixed/String encodings with scale             |
-| `UUID`                         | ✓               | String or fixed byte encoding                       |
-| **Collections**                |                 |                                                     |
-| `List<T>`, `Set<T>`            | ✓               | Generic support for any element type                |
-| `Array<T>`                     | ✓               | Native array support                                |
-| `LongArray`, `IntArray`        | ✓               | Optimized primitive arrays                          |
-| `Map<String, T>`               | ✓               | String keys required by Avro                        |
-| **Binary**                     |                 |                                                     |
-| `ByteArray`                    | ✓               | Direct bytes type                                   |
-| `ByteBuffer`                   | ✓               | Zero-copy when possible                             |
-| **Enums**                      | ✓               | Kotlin enum classes                                 |
-| **Nullable Types**             | ✓               | Full Kotlin null-safety support                     |
-| **Data Classes**               | ✓               | Via reflection or code generation                   |
+| Type                           | Encoder/Decoder | Notes                                                                              |
+|--------------------------------|-----------------|------------------------------------------------------------------------------------|
+| **Primitives**                 |                 |                                                                                    |
+| `Byte`, `Short`                | ✓               | Stored as Avro `INT`; decoders widen from narrower numeric types                   |
+| `Int`, `Long`                  | ✓               | Direct mapping; `LongDecoder` accepts `Int`/`Short`/`Byte`                         |
+| `Float`, `Double`              | ✓               | IEEE 754 floating point; `DoubleDecoder` accepts `Float`                           |
+| `Boolean`                      | ✓               |                                                                                    |
+| **Strings**                    |                 |                                                                                    |
+| `String`                       | ✓               | Schema-driven: encoded as `STRING` (UTF-8/Utf8), `BYTES`, or `FIXED`               |
+| `CharSequence`                 | Decoder only    | `CharSequenceDecoder` — coerces incoming UTF-8/`Utf8`/`String` without conversion  |
+| `Utf8`                         | Decoder only    | `UTF8Decoder` — keeps the Avro-native UTF-8 representation                         |
+| `UUID`                         | Encoder only    | `Utf8UUIDEncoder` (default) or `JavaStringUUIDEncoder`                             |
+| **Temporal Types**             |                 |                                                                                    |
+| `Instant`                      | ✓               | `TimestampMillis`/`TimestampMicros` logical types or raw `LONG` epoch-millis       |
+| `LocalDateTime`                | ✓               | `LocalTimestampMillis`/`LocalTimestampMicros` logical types or raw `LONG`          |
+| `LocalTime`                    | ✓               | `TimeMillis` (`INT`) / `TimeMicros` (`LONG`) logical types                         |
+| `OffsetDateTime`               | ✓               | Round-trips through `Instant` at UTC                                               |
+| **Numeric Types**              |                 |                                                                                    |
+| `BigDecimal`                   | ✓               | Separate encoders/decoders for `BYTES`, `FIXED`, and `STRING` representations      |
+| **Collections**                |                 |                                                                                    |
+| `List<T>`, `Set<T>`            | ✓               | Generic support; primitive/`String` element types use a zero-cost passthrough path |
+| `Array<T>`                     | Encoder only    | `ArrayEncoder` — decoder side returns `List<T>`                                    |
+| `IntArray`, `LongArray`        | ✓               | Specialized primitive arrays, no boxing                                            |
+| `Map<String, T>`               | ✓               | Avro requires `String` keys; preserves insertion order                             |
+| **Binary**                     |                 |                                                                                    |
+| `ByteArray`                    | ✓               | Encoded as `BYTES` or `FIXED` (zero-padded when shorter than `fixedSize`)          |
+| `ByteBuffer`                   | ✓               | Honours `position`/`limit`; never mutates the source buffer                        |
+| **Other**                      |                 |                                                                                    |
+| Enum classes                   | ✓               | Any Kotlin or Java `enum` — uses Avro `ENUM` symbols                               |
+| Nullable types (`T?`)          | ✓               | Encoded as a 2-element union with `null`; full Kotlin null-safety                  |
+| Data classes                   | ✓               | Via reflection (`ReflectionRecord{En,De}coder`) or generated code                  |
 
 ## High-Performance Serde API
 


### PR DESCRIPTION
## Summary
The Avro Type Support table in the README was incomplete and a few rows hid behaviour worth knowing about. Rework it so every encoder/decoder in \`centurion-avro\` is represented and the asymmetries are explicit.

- Add the two decoder-only types that were missing: \`CharSequence\` (\`CharSequenceDecoder\`) and \`Utf8\` (\`UTF8Decoder\`).
- Mark \`UUID\` and \`Array<T>\` as encoder-only and name the two \`UUID\` variants.
- Split \`Byte/Short/Int/Long\` so the widening behaviour of \`LongDecoder\`/\`DoubleDecoder\` shows up.
- Note that \`String\` is schema-driven (STRING/BYTES/FIXED) and that \`BigDecimal\` has separate encoders/decoders for each of its three representations.
- Call out the \`ByteBuffer\` position/limit guarantee, \`FIXED\` zero-padding, primitive-array no-boxing, and \`Map\` insertion-order preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)