### PR TITLE
feat: add BigInteger encoder and decoder

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -3,6 +3,7 @@ package com.sksamuel.centurion.avro.decoders
 import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.LocalDateTime
@@ -41,6 +42,8 @@ fun interface Decoder<T> {
             Byte::class -> ByteDecoder
             Short::class -> ShortDecoder
             BigDecimal::class -> BigDecimalStringDecoder
+            BigInteger::class if nonNullSchema.type == Schema.Type.BYTES -> BigIntegerBytesDecoder
+            BigInteger::class -> BigIntegerStringDecoder
             ByteArray::class -> ByteArrayDecoder
             ByteBuffer::class -> ByteBufferDecoder
             List::class -> {

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigint.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/bigint.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.centurion.avro.decoders
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericFixed
+import java.math.BigInteger
+import java.nio.ByteBuffer
+
+/**
+ * A [Decoder] for [BigInteger] that decodes from Avro BYTES.
+ *
+ * Accepts either a [ByteBuffer] or a [ByteArray]; the input is interpreted as
+ * the two's-complement big-endian byte representation of the integer, matching
+ * [BigInteger.toByteArray].
+ *
+ * Does not mutate the source [ByteBuffer]'s position.
+ */
+object BigIntegerBytesDecoder : Decoder<BigInteger> {
+   override fun decode(schema: Schema, value: Any?): BigInteger {
+      require(schema.type == Schema.Type.BYTES) {
+         "BigIntegerBytesDecoder requires a BYTES schema, was ${schema.type}"
+      }
+      return when (value) {
+         is ByteBuffer -> {
+            val bytes = ByteArray(value.remaining())
+            value.duplicate().get(bytes)
+            BigInteger(bytes)
+         }
+         is ByteArray -> BigInteger(value)
+         is GenericFixed -> BigInteger(value.bytes())
+         else -> error("Unsupported value for BigInteger bytes decoder: ${value?.javaClass?.name}")
+      }
+   }
+}
+
+/**
+ * A [Decoder] for [BigInteger] that decodes from Avro STRINGs.
+ */
+object BigIntegerStringDecoder : Decoder<BigInteger> {
+   override fun decode(schema: Schema, value: Any?): BigInteger {
+      require(schema.type == Schema.Type.STRING) {
+         "BigIntegerStringDecoder requires a STRING schema, was ${schema.type}"
+      }
+      return when (value) {
+         is CharSequence -> BigInteger(value.toString())
+         else -> error("Unsupported value for BigInteger string decoder: ${value?.javaClass?.name}")
+      }
+   }
+}

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -3,6 +3,7 @@ package com.sksamuel.centurion.avro.encoders
 import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.LocalDateTime
@@ -51,6 +52,8 @@ fun interface Encoder<T> {
             Short::class -> ShortEncoder
             Byte::class -> ByteEncoder
             BigDecimal::class -> BigDecimalStringEncoder
+            BigInteger::class if nonNullSchema.type == Schema.Type.BYTES -> BigIntegerBytesEncoder
+            BigInteger::class -> BigIntegerStringEncoder
             ByteBuffer::class -> ByteBufferEncoder
             ByteArray::class -> ByteArrayEncoder
             List::class -> {

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigint.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/bigint.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.centurion.avro.encoders
+
+import org.apache.avro.Schema
+import java.math.BigInteger
+import java.nio.ByteBuffer
+
+/**
+ * An [Encoder] for [BigInteger] that encodes as Avro BYTES using
+ * [BigInteger.toByteArray]'s two's-complement big-endian representation.
+ * The encoded form round-trips losslessly with [BigIntegerBytesDecoder].
+ */
+object BigIntegerBytesEncoder : Encoder<BigInteger> {
+   override fun encode(schema: Schema, value: BigInteger): Any? {
+      require(schema.type == Schema.Type.BYTES) {
+         "BigIntegerBytesEncoder requires a BYTES schema, was ${schema.type}"
+      }
+      return ByteBuffer.wrap(value.toByteArray())
+   }
+}
+
+/**
+ * An [Encoder] for [BigInteger] that encodes as a decimal Avro [Schema.Type.STRING].
+ */
+object BigIntegerStringEncoder : Encoder<BigInteger> {
+   override fun encode(schema: Schema, value: BigInteger): Any? {
+      require(schema.type == Schema.Type.STRING) {
+         "BigIntegerStringEncoder requires a STRING schema, was ${schema.type}"
+      }
+      return StringEncoder.encode(schema, value.toString())
+   }
+}

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/schemas/ReflectionSchemaBuilder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/schemas/ReflectionSchemaBuilder.kt
@@ -2,6 +2,7 @@ package com.sksamuel.centurion.avro.schemas
 
 import org.apache.avro.Schema
 import org.apache.avro.SchemaBuilder
+import java.math.BigInteger
 import java.nio.ByteBuffer
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -39,6 +40,7 @@ class ReflectionSchemaBuilder(
          Float::class -> builder.floatType()
          ByteArray::class -> builder.bytesType()
          ByteBuffer::class -> builder.bytesType()
+         BigInteger::class -> builder.bytesType()
          Set::class -> builder.array().items(schemaFor(type.arguments.first().type!!))
          List::class -> builder.array().items(schemaFor(type.arguments.first().type!!))
          Array::class -> builder.array().items(schemaFor(type.arguments.first().type!!))

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/BigIntegerDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/BigIntegerDecoderTest.kt
@@ -1,0 +1,94 @@
+package com.sksamuel.centurion.avro.decoders
+
+import com.sksamuel.centurion.avro.encoders.BigIntegerBytesEncoder
+import com.sksamuel.centurion.avro.encoders.BigIntegerStringEncoder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
+import java.math.BigInteger
+import java.nio.ByteBuffer
+
+class BigIntegerDecoderTest : FunSpec({
+
+   test("BigIntegerBytesDecoder round-trips through BigIntegerBytesEncoder for positives") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = BigInteger("12345")
+      BigIntegerBytesDecoder.decode(schema, BigIntegerBytesEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("BigIntegerBytesDecoder round-trips for negatives") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = BigInteger("-987654321")
+      BigIntegerBytesDecoder.decode(schema, BigIntegerBytesEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("BigIntegerBytesDecoder round-trips for very large values") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = BigInteger("123456789012345678901234567890")
+      BigIntegerBytesDecoder.decode(schema, BigIntegerBytesEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("BigIntegerBytesDecoder accepts a raw ByteArray") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = BigInteger("12345")
+      BigIntegerBytesDecoder.decode(schema, input.toByteArray()) shouldBe input
+   }
+
+   test("BigIntegerBytesDecoder honours a positioned ByteBuffer") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = BigInteger("1234567")
+      val raw = input.toByteArray()
+      val padded = ByteBuffer.wrap(byteArrayOf(0, 0) + raw)
+      padded.position(2)
+      BigIntegerBytesDecoder.decode(schema, padded) shouldBe input
+   }
+
+   test("BigIntegerBytesDecoder does not mutate the source ByteBuffer position") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val raw = BigInteger("42").toByteArray()
+      val buffer = ByteBuffer.wrap(raw)
+      val before = buffer.position()
+      BigIntegerBytesDecoder.decode(schema, buffer)
+      buffer.position() shouldBe before
+      buffer.remaining() shouldBe raw.size
+   }
+
+   test("BigIntegerBytesDecoder rejects an unsupported value type") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      shouldThrow<IllegalStateException> {
+         BigIntegerBytesDecoder.decode(schema, "not bytes")
+      }
+   }
+
+   test("BigIntegerBytesDecoder rejects a non-BYTES schema") {
+      val schema = Schema.create(Schema.Type.STRING)
+      shouldThrow<IllegalArgumentException> {
+         BigIntegerBytesDecoder.decode(schema, "1".encodeToByteArray())
+      }
+   }
+
+   test("BigIntegerStringDecoder decodes a Kotlin String") {
+      val schema = Schema.create(Schema.Type.STRING)
+      BigIntegerStringDecoder.decode(schema, "12345") shouldBe BigInteger("12345")
+   }
+
+   test("BigIntegerStringDecoder decodes a Utf8 (CharSequence)") {
+      val schema = Schema.create(Schema.Type.STRING)
+      BigIntegerStringDecoder.decode(schema, Utf8("999")) shouldBe BigInteger("999")
+   }
+
+   test("BigIntegerStringDecoder round-trips through BigIntegerStringEncoder") {
+      val schema = Schema.create(Schema.Type.STRING)
+      val input = BigInteger("123456789012345678901234567890")
+      BigIntegerStringDecoder.decode(schema, BigIntegerStringEncoder.encode(schema, input)) shouldBe input
+   }
+
+   test("BigIntegerStringDecoder rejects a non-string value") {
+      val schema = Schema.create(Schema.Type.STRING)
+      shouldThrow<IllegalStateException> {
+         BigIntegerStringDecoder.decode(schema, 12345)
+      }
+   }
+})

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/BigIntegerEncoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/BigIntegerEncoderTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.centurion.avro.encoders
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
+import java.math.BigInteger
+import java.nio.ByteBuffer
+
+class BigIntegerEncoderTest : FunSpec({
+
+   test("BigIntegerBytesEncoder encodes a positive integer as two's-complement BYTES") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val encoded = BigIntegerBytesEncoder.encode(schema, BigInteger("12345")) as ByteBuffer
+      val out = ByteArray(encoded.remaining()).also { encoded.duplicate().get(it) }
+      out shouldBe BigInteger("12345").toByteArray()
+   }
+
+   test("BigIntegerBytesEncoder encodes a negative integer as two's-complement BYTES") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val encoded = BigIntegerBytesEncoder.encode(schema, BigInteger("-1")) as ByteBuffer
+      val out = ByteArray(encoded.remaining()).also { encoded.duplicate().get(it) }
+      out shouldBe byteArrayOf(-1)
+   }
+
+   test("BigIntegerBytesEncoder encodes a large value that does not fit in a Long") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val huge = BigInteger("123456789012345678901234567890")
+      val encoded = BigIntegerBytesEncoder.encode(schema, huge) as ByteBuffer
+      val out = ByteArray(encoded.remaining()).also { encoded.duplicate().get(it) }
+      out shouldBe huge.toByteArray()
+   }
+
+   test("BigIntegerBytesEncoder rejects a non-BYTES schema") {
+      val schema = Schema.create(Schema.Type.STRING)
+      shouldThrow<IllegalArgumentException> {
+         BigIntegerBytesEncoder.encode(schema, BigInteger.ONE)
+      }
+   }
+
+   test("BigIntegerStringEncoder encodes as a Utf8 String") {
+      val schema = Schema.create(Schema.Type.STRING)
+      BigIntegerStringEncoder.encode(schema, BigInteger("12345")) shouldBe Utf8("12345")
+   }
+
+   test("BigIntegerStringEncoder rejects a non-STRING schema") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      shouldThrow<IllegalArgumentException> {
+         BigIntegerStringEncoder.encode(schema, BigInteger.ONE)
+      }
+   }
+})


### PR DESCRIPTION
## Summary
Adds \`BigInteger\` to the list of supported types, mirroring the BigDecimal split.

- \`BigIntegerBytesEncoder\` / \`BigIntegerBytesDecoder\` — Avro \`BYTES\`, using \`BigInteger.toByteArray()\` / \`BigInteger(ByteArray)\` (two's-complement big-endian). Lossless default.
- \`BigIntegerStringEncoder\` / \`BigIntegerStringDecoder\` — Avro \`STRING\`, using \`toString()\` / \`BigInteger(String)\`.

\`Encoder.encoderFor\` / \`Decoder.decoderFor\` pick between the two based on the schema type. \`ReflectionSchemaBuilder\` defaults \`BigInteger\` to \`bytesType()\` so reflection-based serdes pick up the bytes variant automatically.

The bytes decoder reads via \`duplicate().get(...)\` so the caller's \`ByteBuffer\` is not mutated, matching the pattern used by the other byte decoders.

## Test plan
- [x] New \`BigIntegerEncoderTest\` — positive/negative/very-large bytes encoding, schema-type require() guards, and Utf8 string encoding.
- [x] New \`BigIntegerDecoderTest\` — round-trips, raw \`ByteArray\` input, positioned-\`ByteBuffer\` input, position-not-mutated invariant, \`Utf8\` (via \`CharSequence\`) and \`String\` decoding, unsupported-value and unsupported-schema errors.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)