### PR TITLE
perf: SetDecoder direct loops with RandomAccess fast path

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -92,14 +92,32 @@ class SetDecoder<T>(private val decoder: Decoder<T>) : Decoder<Set<T>> {
       val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
+         is List<*> -> {
+            val size = value.size
+            val result = LinkedHashSet<T>(size)
+            if (value is RandomAccess) {
+               for (i in 0 until size) {
+                  result.add(decoder.decode(elementType, value[i]))
+               }
+            } else {
+               for (element in value) {
+                  result.add(decoder.decode(elementType, element))
+               }
+            }
+            result
+         }
          is Collection<*> -> {
             val result = LinkedHashSet<T>(value.size)
-            value.forEach { result.add(decoder.decode(elementType, it)) }
+            for (element in value) {
+               result.add(decoder.decode(elementType, element))
+            }
             result
          }
          is Array<*> -> {
             val result = LinkedHashSet<T>(value.size)
-            value.forEach { result.add(decoder.decode(elementType, it)) }
+            for (i in value.indices) {
+               result.add(decoder.decode(elementType, value[i]))
+            }
             result
          }
          else -> error("Unsupported set type $value")


### PR DESCRIPTION
## Summary
Mirror of #46 / #91 for SetDecoder. The Collection and Array branches were still using \`value.forEach { ... }\`, which allocates a \`Function1\` lambda per call. Replace with direct for-loops and add a \`RandomAccess\` indexed fast path for List inputs (the dominant case from Avro's \`GenericArray\`).

## Test plan
- [x] Existing SetDecoderTest passes.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)