### PR TITLE
perf: skip ByteArrayInputStream in the Lettuce codecs

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/GenericRecordCodec.kt
@@ -7,7 +7,6 @@ import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 
@@ -42,7 +41,7 @@ class GenericRecordCodec(
    private fun decode(buffer: ByteBuffer): GenericRecord {
       val bytes = ByteArray(buffer.remaining())
       buffer.get(bytes)
-      val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
+      val decoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, null)
       return datumReader.read(null, decoder)
    }
 

--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/ReflectionDataClassCodec.kt
@@ -9,7 +9,6 @@ import org.apache.avro.generic.GenericDatumWriter
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import kotlin.reflect.KClass
@@ -48,7 +47,7 @@ class ReflectionDataClassCodec<T : Any>(
    private fun read(buffer: ByteBuffer): GenericRecord {
       val bytes = ByteArray(buffer.remaining())
       buffer.get(bytes)
-      val decoder = decoderFactory.binaryDecoder(ByteArrayInputStream(bytes), null)
+      val decoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, null)
       return datumReader.read(null, decoder)
    }
 


### PR DESCRIPTION
## Summary
Both \`GenericRecordCodec.decode\` and \`ReflectionDataClassCodec.read\` wrapped the freshly-copied bytes in a \`ByteArrayInputStream\` just to hand to \`DecoderFactory.binaryDecoder(InputStream, reuse)\`. The factory has a direct byte-array overload — \`binaryDecoder(byte[], offset, length, reuse)\` — that avoids the stream allocation and its position-tracking state per call.

Switch to the byte-array overload and drop the now-unused \`ByteArrayInputStream\` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)