### PR TITLE
perf: cache GenericDatumReader in BinarySerde

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/io/serde/BinarySerde.kt
@@ -31,6 +31,8 @@ class BinarySerde<T : Any>(
    private val decoderFactory: DecoderFactory,
 ) : Serde<T> {
 
+   private val datumReader = GenericDatumReader<GenericRecord>(schema, schema)
+
    companion object {
 
       /**
@@ -68,8 +70,7 @@ class BinarySerde<T : Any>(
 
    override fun deserialize(bytes: ByteArray): T {
       val binaryDecoder = decoderFactory.binaryDecoder(bytes, 0, bytes.size, null)
-      val datum = GenericDatumReader<GenericRecord>(schema, schema)
-      val record = datum.read(null, binaryDecoder)
+      val record = datumReader.read(null, binaryDecoder)
       return decoder.decode(schema, record)
    }
 }


### PR DESCRIPTION
## Summary
\`BinarySerde.deserialize\` allocated a fresh \`GenericDatumReader<GenericRecord>(schema, schema)\` on every call despite the serde's schema being fixed for its lifetime — the same pattern hoisted in the Lettuce codecs in #47 / #48.

Move the reader to a field. \`GenericDatumReader\` is safe to reuse with a fixed schema; only the \`BinaryDecoder\` is intrinsically per-call.

## Test plan
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)