### PR TITLE
perf: avoid O(n^2) decode on non-RandomAccess lists in primitive array decoders

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/collections.kt
@@ -7,7 +7,21 @@ class IntArrayDecoder(private val decoder: Decoder<Int>) : Decoder<IntArray> {
       val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is List<*> -> IntArray(value.size) { i -> decoder.decode(elementType, value[i]) }
+         is List<*> -> {
+            val size = value.size
+            val result = IntArray(size)
+            if (value is RandomAccess) {
+               for (i in 0 until size) {
+                  result[i] = decoder.decode(elementType, value[i])
+               }
+            } else {
+               var i = 0
+               for (element in value) {
+                  result[i++] = decoder.decode(elementType, element)
+               }
+            }
+            result
+         }
          is Array<*> -> IntArray(value.size) { i -> decoder.decode(elementType, value[i]) }
          else -> error("Unsupported list type $value")
       }
@@ -19,7 +33,21 @@ class LongArrayDecoder(private val decoder: Decoder<Long>) : Decoder<LongArray> 
       val elementType = schema.elementType
       return when (value) {
          // put list first as avro encodes as GenericArray mostly
-         is List<*> -> LongArray(value.size) { i -> decoder.decode(elementType, value[i]) }
+         is List<*> -> {
+            val size = value.size
+            val result = LongArray(size)
+            if (value is RandomAccess) {
+               for (i in 0 until size) {
+                  result[i] = decoder.decode(elementType, value[i])
+               }
+            } else {
+               var i = 0
+               for (element in value) {
+                  result[i++] = decoder.decode(elementType, element)
+               }
+            }
+            result
+         }
          is Array<*> -> LongArray(value.size) { i -> decoder.decode(elementType, value[i]) }
          else -> error("Unsupported list type $value")
       }


### PR DESCRIPTION
## Summary
\`IntArrayDecoder\` and \`LongArrayDecoder\` both used \`IntArray(value.size) { i -> decoder.decode(elementType, value[i]) }\` for the \`List<*>\` branch. The trailing initializer walks i=0..size-1, so for non-\`RandomAccess\` lists — including Avro's own \`GenericData.Array\` in some configurations and JDK \`LinkedList\` — each \`value[i]\` is O(n), making the whole decode O(n²).

Switch the \`List\` branch to a manual fill: indexed access when the list is \`RandomAccess\`, iterator-based fill otherwise. The \`Array<*>\` branch is unchanged (array indexing is already O(1)).

## Test plan
- [x] \`./gradlew :centurion-avro:test\` is green (covers RandomAccess via ArrayList in the existing array-decoder tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)