### PR TITLE
chore: bump Avro to 1.12.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,7 +36,7 @@ dependencyResolutionManagement {
          val tabby = "2.2.11"
          library("sksamuel-tabby", "com.sksamuel.tabby:tabby-fp:$tabby")
 
-         library("avro", "org.apache.avro:avro:1.12.0")
+         library("avro", "org.apache.avro:avro:1.12.1")
 
          library("kotlinx-coroutines-core", "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 


### PR DESCRIPTION
## Summary
Bumps the shared Avro version in the version catalog from 1.12.0 to 1.12.1 — the latest stable on Maven Central. Patch release within the 1.12.x line, no source changes required.

Release notes: https://avro.apache.org/docs/1.12.1/

## Test plan
- [x] \`./gradlew build -x test\` is green.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)