### PR TITLE
docs: remove the Schema Conversion section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,21 +139,6 @@ FileInputStream("users.avro").use { input ->
 }
 ```
 
-## Schema Conversion
-
-Convert a Centurion schema to its Avro counterpart:
-
-```kotlin
-import com.sksamuel.centurion.avro.schemas.toAvroSchema
-
-val centurionSchema = Schema.Struct(
-  Schema.Field("name", Schema.Strings),
-  Schema.Field("age", Schema.Int32)
-)
-
-val avroSchema = centurionSchema.toAvroSchema()
-```
-
 ## Advanced Types
 
 ### Working with Complex Types


### PR DESCRIPTION
## Summary
Drop the standalone Schema Conversion section. The \`toAvroSchema\` helper is already shown in the surrounding Avro Operations / Advanced Types examples, and a dedicated 14-line section to demonstrate one call adds noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)