### PR TITLE
feat: add UUIDDecoder and wire into the decoder dispatch

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/Decoder.kt
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.util.UUID
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
@@ -80,6 +81,7 @@ fun interface Decoder<T> {
             LocalTime::class -> LocalTimeDecoder
             LocalDateTime::class -> LocalDateTimeDecoder
             Instant::class -> InstantDecoder
+            UUID::class -> UUIDDecoder
             is KClass<*> if classifier.java.isEnum -> EnumDecoder(classifier as KClass<out Enum<*>>)
             is KClass<*> if classifier.isData -> ReflectionRecordDecoder(schema, classifier)
             else -> error("No Decoder available for type $type with schema ${schema.type} ($schema)")

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/uuid.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/decoders/uuid.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.centurion.avro.decoders
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericFixed
+import java.nio.ByteBuffer
+import java.util.UUID
+
+/**
+ * A [Decoder] for [UUID].
+ *
+ * Mirrors the encoder side (`Utf8UUIDEncoder` / `JavaStringUUIDEncoder`):
+ * the canonical encoded form is a STRING. Accepts any [CharSequence] —
+ * which covers both Kotlin [String] and Avro's [Utf8].
+ *
+ * Also accepts BYTES / FIXED of length 16, treated as a big-endian
+ * (RFC 4122 network-byte-order) representation of the UUID, matching
+ * the layout used by `UUID.nameUUIDFromBytes(...)` round-trips.
+ */
+object UUIDDecoder : Decoder<UUID> {
+   override fun decode(schema: Schema, value: Any?): UUID {
+      return when (value) {
+         is CharSequence -> UUID.fromString(value.toString())
+         is ByteArray -> fromBytes(value)
+         is GenericFixed -> fromBytes(value.bytes())
+         is ByteBuffer -> {
+            val bytes = ByteArray(value.remaining())
+            value.duplicate().get(bytes)
+            fromBytes(bytes)
+         }
+         else -> error("Cannot decode ${value?.javaClass?.name} as UUID: $value")
+      }
+   }
+
+   private fun fromBytes(bytes: ByteArray): UUID {
+      require(bytes.size == 16) { "UUID byte representation must be exactly 16 bytes, was ${bytes.size}" }
+      val buffer = ByteBuffer.wrap(bytes)
+      val msb = buffer.long
+      val lsb = buffer.long
+      return UUID(msb, lsb)
+   }
+}

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/UUIDDecoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/decoders/UUIDDecoderTest.kt
@@ -1,0 +1,83 @@
+package com.sksamuel.centurion.avro.decoders
+
+import com.sksamuel.centurion.avro.encoders.JavaStringUUIDEncoder
+import com.sksamuel.centurion.avro.encoders.Utf8UUIDEncoder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.Utf8
+import java.nio.ByteBuffer
+import java.util.UUID
+
+class UUIDDecoderTest : FunSpec({
+
+   val uuid: UUID = UUID.fromString("c0a80101-1d3e-11ed-861d-0242ac120002")
+   val stringSchema = Schema.create(Schema.Type.STRING)
+   val bytesSchema = Schema.create(Schema.Type.BYTES)
+   val fixedSchema: Schema = SchemaBuilder.builder().fixed("uuid").size(16)
+
+   test("decodes a Kotlin String") {
+      UUIDDecoder.decode(stringSchema, uuid.toString()) shouldBe uuid
+   }
+
+   test("decodes a Utf8 (CharSequence)") {
+      UUIDDecoder.decode(stringSchema, Utf8(uuid.toString())) shouldBe uuid
+   }
+
+   test("round-trips through Utf8UUIDEncoder") {
+      UUIDDecoder.decode(stringSchema, Utf8UUIDEncoder.encode(stringSchema, uuid)) shouldBe uuid
+   }
+
+   test("round-trips through JavaStringUUIDEncoder") {
+      UUIDDecoder.decode(stringSchema, JavaStringUUIDEncoder.encode(stringSchema, uuid)) shouldBe uuid
+   }
+
+   test("decodes from a 16-byte ByteArray (big-endian)") {
+      val bytes = ByteBuffer.allocate(16).putLong(uuid.mostSignificantBits).putLong(uuid.leastSignificantBits).array()
+      UUIDDecoder.decode(bytesSchema, bytes) shouldBe uuid
+   }
+
+   test("decodes from a positioned ByteBuffer") {
+      val bytes = ByteBuffer.allocate(16).putLong(uuid.mostSignificantBits).putLong(uuid.leastSignificantBits).array()
+      val padded = ByteBuffer.wrap(byteArrayOf(0, 0) + bytes)
+      padded.position(2)
+      UUIDDecoder.decode(bytesSchema, padded) shouldBe uuid
+   }
+
+   test("does not mutate the source ByteBuffer position") {
+      val bytes = ByteBuffer.allocate(16).putLong(uuid.mostSignificantBits).putLong(uuid.leastSignificantBits).array()
+      val buffer = ByteBuffer.wrap(bytes)
+      val before = buffer.position()
+      UUIDDecoder.decode(bytesSchema, buffer)
+      buffer.position() shouldBe before
+      buffer.remaining() shouldBe 16
+   }
+
+   test("decodes from a GenericFixed of size 16") {
+      val bytes = ByteBuffer.allocate(16).putLong(uuid.mostSignificantBits).putLong(uuid.leastSignificantBits).array()
+      val fixed = GenericData.get().createFixed(null, bytes, fixedSchema) as GenericData.Fixed
+      UUIDDecoder.decode(fixedSchema, fixed) shouldBe uuid
+   }
+
+   test("rejects a byte array of the wrong length") {
+      shouldThrow<IllegalArgumentException> {
+         UUIDDecoder.decode(bytesSchema, byteArrayOf(1, 2, 3))
+      }
+   }
+
+   test("rejects a non-supported value type") {
+      shouldThrow<IllegalStateException> {
+         UUIDDecoder.decode(stringSchema, 123)
+      }
+   }
+
+   test("decoderFor returns UUIDDecoder for UUID") {
+      Decoder.decoderFor(typeOfUuid(), stringSchema) shouldBe UUIDDecoder
+   }
+})
+
+private fun typeOfUuid() = ::sample.returnType
+private val sample: UUID get() = UUID.randomUUID()


### PR DESCRIPTION
## Summary
Adds a decoder counterpart to the existing UUID encoders. Until now \`UUID\` only had encoder support — the dispatch table had no entry for it on the decoder side, so reflection-based round-trips would fail.

- Canonical input is a \`STRING\` (accepts any \`CharSequence\`, covering both \`String\` and Avro's \`Utf8\`).
- Also accepts \`ByteArray\` / \`ByteBuffer\` / \`GenericFixed\` of length 16, interpreted as the big-endian RFC 4122 representation. A 16-byte FIXED schema round-trips cleanly.
- Bytes path uses \`duplicate().get(...)\` so the caller's \`ByteBuffer\` position is not mutated.

Wired into \`Decoder.decoderFor\` so reflection-based dispatch picks it up automatically.

## Test plan
- [x] New \`UUIDDecoderTest\` — String/Utf8 inputs, round-trip via both encoder variants, ByteArray / positioned ByteBuffer / GenericFixed inputs, position-not-mutated invariant, wrong-length and wrong-type error paths, and dispatch.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)