### PR TITLE
feat: add Utf8Encoder and wire into the encoder dispatch

### DIFF
--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/Encoder.kt
@@ -2,6 +2,7 @@ package com.sksamuel.centurion.avro.encoders
 
 import com.sksamuel.centurion.avro.schemas.unionNonNullComponent
 import org.apache.avro.Schema
+import org.apache.avro.util.Utf8
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.nio.ByteBuffer
@@ -44,6 +45,7 @@ fun interface Encoder<T> {
             String::class if nonNullSchema.type == Schema.Type.BYTES -> ByteStringEncoder
             String::class if nonNullSchema.type == Schema.Type.FIXED -> FixedStringEncoder
             String::class -> StringEncoder
+            Utf8::class -> Utf8Encoder
             Boolean::class -> BooleanEncoder
             Float::class -> FloatEncoder
             Double::class -> DoubleEncoder

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/encoders/strings.kt
@@ -51,6 +51,37 @@ object UTF8StringEncoder : Encoder<String> {
 }
 
 /**
+ * An [Encoder] for [Utf8] values, dispatched on the schema type in the same
+ * way as [StringEncoder]. For `STRING` schemas the input is returned as-is;
+ * for `BYTES` the underlying bytes are wrapped in a [ByteBuffer]; for `FIXED`
+ * they are copied into a [GenericData.Fixed] of the schema's `fixedSize`,
+ * zero-padded when shorter.
+ */
+object Utf8Encoder : Encoder<Utf8> {
+   override fun encode(schema: Schema, value: Utf8): Any? {
+      return when (schema.type) {
+         Schema.Type.STRING -> value
+         Schema.Type.BYTES -> {
+            val length = value.byteLength
+            val copy = ByteArray(length)
+            System.arraycopy(value.bytes, 0, copy, 0, length)
+            ByteBuffer.wrap(copy)
+         }
+         Schema.Type.FIXED -> {
+            val length = value.byteLength
+            val fixedSize = schema.fixedSize
+            if (length > fixedSize)
+               error("Cannot write Utf8 with $length bytes to fixed type of size $fixedSize")
+            val padded = ByteArray(fixedSize)
+            System.arraycopy(value.bytes, 0, padded, 0, length)
+            GenericData.Fixed(schema, padded)
+         }
+         else -> error("Unsupported type for Utf8 schema: $schema")
+      }
+   }
+}
+
+/**
  * An [Encoder] for Strings that encodes as [ByteBuffer]s.
  */
 object ByteStringEncoder : Encoder<String> {

--- a/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/schemas/ReflectionSchemaBuilder.kt
+++ b/centurion-avro/src/main/kotlin/com/sksamuel/centurion/avro/schemas/ReflectionSchemaBuilder.kt
@@ -2,6 +2,7 @@ package com.sksamuel.centurion.avro.schemas
 
 import org.apache.avro.Schema
 import org.apache.avro.SchemaBuilder
+import org.apache.avro.util.Utf8
 import java.math.BigInteger
 import java.nio.ByteBuffer
 import kotlin.reflect.KClass
@@ -31,6 +32,7 @@ class ReflectionSchemaBuilder(
 
       val schema: Schema = when (val classifier = type.classifier) {
          String::class -> if (useJavaString) STRING_SCHEMA_JAVA else STRING_SCHEMA
+         Utf8::class -> STRING_SCHEMA
          Boolean::class -> builder.booleanType()
          Int::class -> builder.intType()
          Long::class -> builder.longType()

--- a/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/Utf8EncoderTest.kt
+++ b/centurion-avro/src/test/kotlin/com/sksamuel/centurion/avro/encoders/Utf8EncoderTest.kt
@@ -1,0 +1,79 @@
+package com.sksamuel.centurion.avro.encoders
+
+import com.sksamuel.centurion.avro.decoders.UTF8Decoder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.apache.avro.Schema
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.apache.avro.util.Utf8
+import java.nio.ByteBuffer
+
+class Utf8EncoderTest : FunSpec({
+
+   test("STRING schema returns the Utf8 unchanged") {
+      val schema = Schema.create(Schema.Type.STRING)
+      val input = Utf8("hello")
+      Utf8Encoder.encode(schema, input) shouldBe input
+   }
+
+   test("BYTES schema wraps the bytes in a fresh ByteBuffer") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val encoded = Utf8Encoder.encode(schema, Utf8("hi")) as ByteBuffer
+      val out = ByteArray(encoded.remaining()).also { encoded.duplicate().get(it) }
+      out shouldBe "hi".encodeToByteArray()
+   }
+
+   test("BYTES schema copies (does not share the Utf8 backing array)") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = Utf8("abc")
+      val encoded = Utf8Encoder.encode(schema, input) as ByteBuffer
+      // mutating the source should not affect the encoded buffer
+      input.bytes[0] = 'Z'.code.toByte()
+      val out = ByteArray(encoded.remaining()).also { encoded.duplicate().get(it) }
+      out shouldBe "abc".encodeToByteArray()
+   }
+
+   test("FIXED schema returns a GenericFixed of the right size, zero-padded") {
+      val schema: Schema = SchemaBuilder.builder().fixed("f").size(5)
+      val encoded = Utf8Encoder.encode(schema, Utf8("hi")) as GenericData.Fixed
+      encoded.bytes() shouldBe byteArrayOf('h'.code.toByte(), 'i'.code.toByte(), 0, 0, 0)
+   }
+
+   test("FIXED rejects oversize input with a useful message") {
+      val schema: Schema = SchemaBuilder.builder().fixed("f").size(2)
+      val ex = shouldThrow<IllegalStateException> {
+         Utf8Encoder.encode(schema, Utf8("abcd"))
+      }
+      ex.message!! shouldContain "4"
+      ex.message!! shouldContain "2"
+   }
+
+   test("rejects unsupported schema types") {
+      val schema = Schema.create(Schema.Type.INT)
+      shouldThrow<IllegalStateException> {
+         Utf8Encoder.encode(schema, Utf8("x"))
+      }
+   }
+
+   test("round-trips through UTF8Decoder on a STRING schema") {
+      val schema = Schema.create(Schema.Type.STRING)
+      val input = Utf8("round-trip me")
+      UTF8Decoder.decode(schema, Utf8Encoder.encode(schema, input)) shouldBe input
+   }
+
+   test("round-trips through UTF8Decoder on a BYTES schema") {
+      val schema = Schema.create(Schema.Type.BYTES)
+      val input = Utf8("bytes path")
+      UTF8Decoder.decode(schema, Utf8Encoder.encode(schema, input)) shouldBe input
+   }
+
+   test("encoderFor returns Utf8Encoder for a Utf8 field") {
+      val schema = Schema.create(Schema.Type.STRING)
+      Encoder.encoderFor(::sample.returnType, schema) shouldBe Utf8Encoder
+   }
+})
+
+private val sample: Utf8 get() = Utf8("")


### PR DESCRIPTION
## Summary
\`UTF8Decoder\` had no encoder counterpart, so a data class with a \`Utf8\` field couldn't round-trip through reflection-based encoding.

Add a schema-driven \`Utf8Encoder\`, modelled on \`StringEncoder\`:

| Schema | Behaviour |
|---|---|
| \`STRING\` | Return the \`Utf8\` as-is (Avro's binary writer accepts it natively). |
| \`BYTES\` | Copy the underlying bytes into a fresh \`ByteBuffer\`. We can't reuse \`Utf8.getBytes()\` directly because the backing array is reused internally. |
| \`FIXED\` | Copy into a \`GenericData.Fixed\` of \`schema.fixedSize\`, zero-padded when shorter; explicit error when longer. |
| other | error. |

Wire into \`Encoder.encoderFor\` and teach \`ReflectionSchemaBuilder\` to map \`Utf8\` to a STRING schema by default.

## Test plan
- [x] New \`Utf8EncoderTest\` — STRING / BYTES (with backing-array isolation check) / FIXED (padding + oversize error) / other-schema rejection, round-trip through \`UTF8Decoder\` on both STRING and BYTES, and dispatch.
- [x] \`./gradlew :centurion-avro:test\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)