### PR TITLE
example: add centurion-examples-spring-grpc fortune-cookie service

### DIFF
--- a/centurion-examples-spring-grpc/README.md
+++ b/centurion-examples-spring-grpc/README.md
@@ -1,0 +1,39 @@
+# centurion-examples-spring-grpc
+
+A minimal Spring Boot + Spring gRPC application demonstrating
+[`centurion-spring-grpc`](../centurion-spring-grpc). Exposes a single
+`example.FortuneCookie` service that returns a random fortune.
+
+## What's in here
+
+- `FortuneCookie.kt` — `FortuneRequest` and `FortuneResponse` data classes.
+  These are plain Kotlin data classes; centurion-avro builds reflection-based
+  encoders/decoders for them at runtime.
+- `FortuneCookieService.kt` — the service implementation. Builds the
+  `ServerServiceDefinition` using `AvroMethodDescriptors.unary(...)` from
+  `centurion-spring-grpc`, so the wire format is Avro binary.
+- `FortuneCookieApplication.kt` — `@SpringBootApplication` entry point. The
+  `centurion-spring-grpc` auto-configuration picks up any
+  `ServerServiceDefinition` bean and attaches it to the embedded gRPC server.
+- `application.yml` — server configuration (port 9090 by default).
+
+## Running
+
+```
+./gradlew :centurion-examples-spring-grpc:bootRun
+```
+
+The service binds to `0.0.0.0:9090` and exposes one unary RPC:
+
+| Full method                 | Request           | Response                    |
+|-----------------------------|-------------------|-----------------------------|
+| `example.FortuneCookie/Pick` | `FortuneRequest`  | `FortuneResponse`           |
+
+Pass `FortuneRequest(seed = 42L)` for a deterministic response (useful for
+testing); `seed = 0L` (the default) uses the system random.
+
+## Calling the service from Kotlin
+
+The same `AvroMethodDescriptors.unary<Req, Resp>(...)` factory works on the
+client side — pair it with `io.grpc.stub.ClientCalls.blockingUnaryCall` or
+the async variants. See `FortuneCookieServiceTest` for an in-process example.

--- a/centurion-examples-spring-grpc/build.gradle.kts
+++ b/centurion-examples-spring-grpc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+   id("kotlin-conventions")
+}
+
+dependencies {
+   implementation(projects.centurionSpringGrpc)
+   implementation(libs.spring.grpc.server.starter)
+   implementation("org.springframework.boot:spring-boot-starter:3.4.5")
+   implementation("io.grpc:grpc-stub:1.72.0")
+
+   testImplementation("org.springframework.boot:spring-boot-starter-test:3.4.5")
+   testImplementation("org.springframework.grpc:spring-grpc-test:0.8.0")
+   testImplementation("io.grpc:grpc-inprocess:1.72.0")
+}

--- a/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookie.kt
+++ b/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookie.kt
@@ -1,0 +1,16 @@
+package com.sksamuel.centurion.examples.grpc
+
+/**
+ * Domain types for the example `example.FortuneCookie` gRPC service.
+ *
+ * These are plain Kotlin data classes. [com.sksamuel.centurion.spring.grpc.AvroMarshaller]
+ * builds reflection-based encoders/decoders for them at runtime; the same wire format
+ * is used on the client and server because they share these classes.
+ */
+data class FortuneRequest(
+   val seed: Long = 0L,
+)
+
+data class FortuneResponse(
+   val fortune: String,
+)

--- a/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieApplication.kt
+++ b/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieApplication.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.centurion.examples.grpc
+
+import io.grpc.ServerServiceDefinition
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+
+/**
+ * Sample Spring Boot application that exposes the `example.FortuneCookie` gRPC service
+ * with Avro-encoded request/response payloads via centurion-spring-grpc.
+ *
+ * On startup, Spring Boot picks up the `CenturionGrpcAutoConfiguration` from
+ * `centurion-spring-grpc`, which collects every `ServerServiceDefinition` bean — including
+ * the one defined below — and attaches them to the embedded gRPC server.
+ *
+ * Run with `./gradlew :centurion-examples-spring-grpc:bootRun` (or the equivalent
+ * `main` entry point in your IDE); the service listens on whatever port Spring gRPC's
+ * starter is configured for (default 9090 — see `application.yml`).
+ */
+@SpringBootApplication
+class FortuneCookieApplication {
+
+   @Bean
+   fun fortuneCookieService(): FortuneCookieService = FortuneCookieService()
+
+   /**
+    * Expose the service binding as a [ServerServiceDefinition] bean. The auto-configuration
+    * picks every such bean up and registers it on the gRPC server builder.
+    */
+   @Bean
+   fun fortuneCookieServiceDefinition(service: FortuneCookieService): ServerServiceDefinition =
+      service.bindService()
+}
+
+fun main(args: Array<String>) {
+   runApplication<FortuneCookieApplication>(*args)
+}

--- a/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieService.kt
+++ b/centurion-examples-spring-grpc/src/main/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieService.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.centurion.examples.grpc
+
+import com.sksamuel.centurion.spring.grpc.AvroMethodDescriptors
+import io.grpc.ServerCallHandler
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.ServerCalls
+import kotlin.random.Random
+
+/**
+ * Server-side implementation of the `example.FortuneCookie` service.
+ *
+ * Exposes a single unary RPC, `Pick`, that returns a randomly chosen fortune. If the
+ * request carries a non-zero `seed`, the random source is seeded with it so callers
+ * can get deterministic responses (useful for tests).
+ */
+class FortuneCookieService(
+   private val fortunes: List<String> = DEFAULT_FORTUNES,
+) {
+
+   /**
+    * Build a [ServerServiceDefinition] for `example.FortuneCookie` with Avro marshallers.
+    *
+    * The descriptor's full method name is `example.FortuneCookie/Pick`. Both the request
+    * and response wire types are Avro binary, schemaless — see [AvroMethodDescriptors].
+    */
+   fun bindService(): ServerServiceDefinition {
+      val pick = AvroMethodDescriptors.unary<FortuneRequest, FortuneResponse>(
+         fullMethodName = "$SERVICE_NAME/$PICK_METHOD",
+      )
+
+      val pickHandler: ServerCallHandler<FortuneRequest, FortuneResponse> =
+         ServerCalls.asyncUnaryCall { request, responseObserver ->
+            val random = if (request.seed == 0L) Random.Default else Random(request.seed)
+            val fortune = fortunes[random.nextInt(fortunes.size)]
+            responseObserver.onNext(FortuneResponse(fortune))
+            responseObserver.onCompleted()
+         }
+
+      return ServerServiceDefinition.builder(SERVICE_NAME)
+         .addMethod(pick, pickHandler)
+         .build()
+   }
+
+   companion object {
+      const val SERVICE_NAME = "example.FortuneCookie"
+      const val PICK_METHOD = "Pick"
+
+      val DEFAULT_FORTUNES: List<String> = listOf(
+         "A bold venture begins today.",
+         "Good things come to those who automate.",
+         "Reuse a serde — your future self will thank you.",
+         "Beware of the off-by-one error.",
+         "Read the schema. Trust the schema.",
+         "Today is a good day to ship a small PR.",
+         "The cache that is never invalidated is no cache at all.",
+         "Patience is a virtue. Idempotence is a feature.",
+         "A green build is worth a thousand hopes.",
+         "Comments lie. Tests don't.",
+      )
+   }
+}

--- a/centurion-examples-spring-grpc/src/main/resources/application.yml
+++ b/centurion-examples-spring-grpc/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: centurion-fortune-cookie
+
+  grpc:
+    server:
+      port: 9090
+      host: 0.0.0.0

--- a/centurion-examples-spring-grpc/src/test/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieServiceTest.kt
+++ b/centurion-examples-spring-grpc/src/test/kotlin/com/sksamuel/centurion/examples/grpc/FortuneCookieServiceTest.kt
@@ -1,0 +1,54 @@
+package com.sksamuel.centurion.examples.grpc
+
+import com.sksamuel.centurion.spring.grpc.AvroMethodDescriptors
+import io.grpc.ManagedChannel
+import io.grpc.Server
+import io.grpc.inprocess.InProcessChannelBuilder
+import io.grpc.inprocess.InProcessServerBuilder
+import io.grpc.stub.ClientCalls
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.util.UUID
+
+class FortuneCookieServiceTest : FunSpec({
+
+   lateinit var server: Server
+   lateinit var channel: ManagedChannel
+
+   beforeSpec {
+      val serverName = "fortune-test-${UUID.randomUUID()}"
+      server = InProcessServerBuilder.forName(serverName)
+         .directExecutor()
+         .addService(FortuneCookieService().bindService())
+         .build()
+         .start()
+      channel = InProcessChannelBuilder.forName(serverName).directExecutor().build()
+   }
+
+   afterSpec {
+      channel.shutdownNow()
+      server.shutdownNow()
+   }
+
+   val pick = AvroMethodDescriptors.unary<FortuneRequest, FortuneResponse>(
+      "${FortuneCookieService.SERVICE_NAME}/${FortuneCookieService.PICK_METHOD}",
+   )
+
+   test("Pick returns a non-empty fortune") {
+      val response = ClientCalls.blockingUnaryCall(channel, pick, io.grpc.CallOptions.DEFAULT, FortuneRequest())
+      response.fortune.shouldNotBeEmpty()
+   }
+
+   test("Pick returns a fortune from the configured list") {
+      val response = ClientCalls.blockingUnaryCall(channel, pick, io.grpc.CallOptions.DEFAULT, FortuneRequest())
+      FortuneCookieService.DEFAULT_FORTUNES shouldContain response.fortune
+   }
+
+   test("Pick is deterministic for a fixed seed") {
+      val first = ClientCalls.blockingUnaryCall(channel, pick, io.grpc.CallOptions.DEFAULT, FortuneRequest(seed = 42L))
+      val second = ClientCalls.blockingUnaryCall(channel, pick, io.grpc.CallOptions.DEFAULT, FortuneRequest(seed = 42L))
+      first.fortune shouldBe second.fortune
+   }
+})

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 include("centurion-avro")
 include("centurion-avro-lettuce")
 include("centurion-spring-grpc")
+include("centurion-examples-spring-grpc")
 //include("centurion-avro-gradle-plugin")
 include("centurion-benchmarks")
 


### PR DESCRIPTION
## Summary
A minimal Spring Boot + Spring gRPC application demonstrating the existing \`centurion-spring-grpc\` module. Exposes a single \`example.FortuneCookie\` gRPC service with one unary RPC, \`Pick\`, that returns a random fortune string.

| Component | Notes |
|---|---|
| \`FortuneRequest\` / \`FortuneResponse\` | Plain Kotlin data classes; reflection-based Avro serdes built at runtime. |
| \`FortuneCookieService.bindService()\` | Builds a \`ServerServiceDefinition\` using \`AvroMethodDescriptors.unary(...)\`; wire format is Avro binary. |
| \`FortuneCookieApplication\` | \`@SpringBootApplication\`; exposes the service binding as a bean for \`CenturionGrpcAutoConfiguration\` to pick up. |
| \`application.yml\` | Server on port 9090 by default. |
| \`FortuneCookieServiceTest\` | In-process gRPC test — happy path, deterministic seed, response is one of the configured fortunes. |
| \`README.md\` | How to run + a one-line table of the available RPC. |

## Test plan
- [x] \`./gradlew :centurion-examples-spring-grpc:test\` is green.
- [x] \`./gradlew :centurion-examples-spring-grpc:compileKotlin\` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)