### PR TITLE
refactor: rename ReflectionDataClassCodec to AvroCodec

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodec.kt
@@ -16,11 +16,13 @@ import kotlin.reflect.KClass
 /**
  * A [RedisCodec] for encoding and decoding data classes using Avro.
  */
-class ReflectionDataClassCodec<T : Any>(
+class AvroCodec<T : Any>(
    private val encoderFactory: EncoderFactory,
    private val decoderFactory: DecoderFactory,
    kclass: KClass<T>,
 ) : RedisCodec<T, T> {
+
+   constructor(kclass: KClass<T>) : this(EncoderFactory.get(), DecoderFactory.get(), kclass)
 
    private val schema = ReflectionSchemaBuilder().schema(kclass)
    private val encoder = ReflectionRecordEncoder(schema, kclass)
@@ -59,3 +61,6 @@ class ReflectionDataClassCodec<T : Any>(
       return ByteBuffer.wrap(baos.toByteArray())
    }
 }
+
+@Deprecated("Renamed to AvroCodec", ReplaceWith("AvroCodec<T>"))
+typealias ReflectionDataClassCodec<T> = AvroCodec<T>

--- a/centurion-avro-lettuce/src/test/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodecTest.kt
+++ b/centurion-avro-lettuce/src/test/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodecTest.kt
@@ -9,13 +9,13 @@ import kotlinx.coroutines.future.await
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
 
-class ReflectionDataClassCodecTest : FunSpec({
+class AvroCodecTest : FunSpec({
 
    val redis = install(redisExtension)
 
    test("happy path") {
 
-      val valueCodec = ReflectionDataClassCodec(
+      val valueCodec = AvroCodec(
          encoderFactory = EncoderFactory.get(),
          decoderFactory = DecoderFactory.get(),
          Foo::class,
@@ -32,11 +32,7 @@ class ReflectionDataClassCodecTest : FunSpec({
 
    test("lists of records") {
 
-      val valueCodec = ReflectionDataClassCodec(
-         encoderFactory = EncoderFactory.get(),
-         decoderFactory = DecoderFactory.get(),
-         Wrapper::class,
-      )
+      val valueCodec = AvroCodec(Wrapper::class)
 
       val keyCodec = StringCodec.UTF8
       val conn = redis.toConnection(codec = RedisCodec.of(keyCodec, valueCodec))


### PR DESCRIPTION
## Summary
- Renames `ReflectionDataClassCodec` to `AvroCodec` (file + class + test).
- Adds a `@Deprecated` typealias `ReflectionDataClassCodec<T> = AvroCodec<T>` so existing call sites keep compiling.
- Adds a convenience constructor `AvroCodec(kclass: KClass<T>)` that defaults to `EncoderFactory.get()` / `DecoderFactory.get()`.

## Test plan
- [x] `./gradlew :centurion-avro-lettuce:compileKotlin :centurion-avro-lettuce:compileTestKotlin`
- [ ] Existing `AvroCodecTest` (happy path + lists of records) passes against the redis testcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)