### PR TITLE
feat: add reified factory functions for AvroCodec

### DIFF
--- a/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodec.kt
+++ b/centurion-avro-lettuce/src/main/kotlin/com/sksamuel/centurion/avro/lettuce/AvroCodec.kt
@@ -64,3 +64,10 @@ class AvroCodec<T : Any>(
 
 @Deprecated("Renamed to AvroCodec", ReplaceWith("AvroCodec<T>"))
 typealias ReflectionDataClassCodec<T> = AvroCodec<T>
+
+inline fun <reified T : Any> AvroCodec(): AvroCodec<T> = AvroCodec(T::class)
+
+inline fun <reified T : Any> AvroCodec(
+   encoderFactory: EncoderFactory,
+   decoderFactory: DecoderFactory,
+): AvroCodec<T> = AvroCodec(encoderFactory, decoderFactory, T::class)


### PR DESCRIPTION
## Summary
- Adds two inline reified factory functions so callers can use type inference instead of passing a `KClass` explicitly:
  - `AvroCodec<Foo>()` — uses default `EncoderFactory.get()` / `DecoderFactory.get()`
  - `AvroCodec<Foo>(encoderFactory, decoderFactory)` — explicit factories
- Stacked on top of #112 (the rename PR). Re-target to `master` once #112 merges.

## Test plan
- [x] `./gradlew :centurion-avro-lettuce:compileKotlin :centurion-avro-lettuce:compileTestKotlin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)